### PR TITLE
Fix vault placement sending the profile UID instead of the character ID

### DIFF
--- a/dayz_code/actions/vault_pitch.sqf
+++ b/dayz_code/actions/vault_pitch.sqf
@@ -144,8 +144,8 @@ if(!_cancel) then {
 		_tent setVariable ["characterID",dayz_playerUID,true];
 		_tent setVariable ["OEMPos",_location,true];
 
-		//["dayzPublishObj",[dayz_playerUID,_tent,[_dir,_location],"VaultStorageLocked"]] call callRpcProcedure;
-		dayzPublishObj = [dayz_playerUID,_tent,[_dir,_location],"VaultStorageLocked"];
+		//["dayzPublishObj",[dayz_characterID,_tent,[_dir,_location],"VaultStorageLocked"]] call callRpcProcedure;
+		dayzPublishObj = [dayz_characterID,_tent,[_dir,_location],"VaultStorageLocked"];
 		publicVariableServer  "dayzPublishObj";
 	
 		cutText ["You have setup your Safe", "PLAIN DOWN"];


### PR DESCRIPTION
Currently the client is sending the player's profile UID instead of the character ID, not only is this incorrect, it also prevents anyone with an anniversary edition from placing vaults as their profile ID contains 'AX' which can not be cast to int. This patch corrects this.
