### PR TITLE
Check for _needNear produces errors because "X" in _array can't be used ...

### DIFF
--- a/SQF/dayz_code/actions/player_build.sqf
+++ b/SQF/dayz_code/actions/player_build.sqf
@@ -50,26 +50,30 @@ _needNear = 	getArray (configFile >> "CfgMagazines" >> _item >> "ItemActions" >>
 {
 	_need = _x select 0;
 	_distance = _x select 1;
-
-	if("fire" in _need) then {
-		_isNear = {inflamed _x} count (position player nearObjects _distance);
-		if(_isNear == 0) then {  
-			_abort = true;
-			_reason = "fire";
+	switch(_need) do{
+		case "fire":
+		{
+			_isNear = {inflamed _x} count (position player nearObjects _distance);
+			if(_isNear == 0) then {  
+				_abort = true;
+				_reason = "fire";
+			};
 		};
-	};
-	if("workshop" in _need) then {
-		_isNear = count (nearestObjects [player, ["Wooden_shed_DZ","WoodShack_DZ","WorkBench_DZ"], _distance]);
-		if(_isNear == 0) then {  
-			_abort = true;
-			_reason = "workshop";
+		case "workshop":
+		{
+			_isNear = count (nearestObjects [player, ["Wooden_shed_DZ","WoodShack_DZ","WorkBench_DZ"], _distance]);
+			if(_isNear == 0) then {  
+				_abort = true;
+				_reason = "workshop";
+			};
 		};
-	};
-	if("fueltank" in _need) then {
-		_isNear = count (nearestObjects [player, dayz_fuelsources, _distance]);
-		if(_isNear == 0) then {  
-			_abort = true;
-			_reason = "fuel tank";
+		case "fueltank":
+		{
+			_isNear = count (nearestObjects [player, dayz_fuelsources, _distance]);
+			if(_isNear == 0) then {  
+				_abort = true;
+				_reason = "fuel tank";
+			};
 		};
 	};
 } forEach _needNear;


### PR DESCRIPTION
...on a string.

My previous fix included a broken default part.. now it's working as inteded without any extra stuff.
