### PR TITLE
Fixed Upgraded Black SUV Glass Armor

### DIFF
--- a/SQF/dayz_code/Configs/CfgVehicles/LAND/SUV.hpp
+++ b/SQF/dayz_code/Configs/CfgVehicles/LAND/SUV.hpp
@@ -457,19 +457,19 @@ class SUV_TK_CIV_EP1_DZE2: SUV_TK_CIV_EP1_DZE1
 		};
 		class HitGlass1: HitGlass1
 		{
-			armor = 0.1;
+			armor = 2;
 		};
 		class HitGlass2: HitGlass2
 		{
-			armor = 0.1;
+			armor = 2;
 		};
 		class HitGlass3: HitGlass3
 		{
-			armor = 0.1;
+			armor = 2;
 		};
 		class HitGlass4: HitGlass4
 		{
-			armor = 0.1;
+			armor = 2;
 		};
 	};
 };


### PR DESCRIPTION
The glass armor of the upgraded black SUV (SUV_TK_CIV_EP1_DZE1) was less than when not upgraded, and did not match the glass armor of the other upgraded SUVs.
