### PR TITLE
Convert G36 and G36SD Ammo To STANAG Variant

### DIFF
--- a/SQF/dayz_code/compile/spawn_loot.sqf
+++ b/SQF/dayz_code/compile/spawn_loot.sqf
@@ -100,6 +100,8 @@ switch (_iClass) do
 		{
 			if (_mags select 0 == "Quiver") then { _mags set [0, "WoodenArrow"] }; // Prevent spawning a Quiver
 			if (_mags select 0 == "20Rnd_556x45_Stanag") then { _mags set [0, "30Rnd_556x45_Stanag"] };
+			if (_mags select 0 == "30Rnd_556x45_G36") then { _mags set [0, "30Rnd_556x45_Stanag"] };
+			if (_mags select 0 == "30Rnd_556x45_G36SD") then { _mags set [0, "30Rnd_556x45_StanagSD"] };
 			_item addMagazineCargoGlobal [(_mags select 0), (round(random 2))];
 		};
 		
@@ -114,6 +116,8 @@ switch (_iClass) do
 		{
 			if (_mags select 0 == "Quiver") then { _mags set [0, "WoodenArrow"] }; // Prevent spawning a Quiver
 			if (_mags select 0 == "20Rnd_556x45_Stanag") then { _mags set [0, "30Rnd_556x45_Stanag"] };
+			if (_mags select 0 == "30Rnd_556x45_G36") then { _mags set [0, "30Rnd_556x45_Stanag"] };
+			if (_mags select 0 == "30Rnd_556x45_G36SD") then { _mags set [0, "30Rnd_556x45_StanagSD"] };
 			_item addMagazineCargoGlobal [(_mags select 0), (round(random 2))];
 		};
 	};


### PR DESCRIPTION
By converting the G36 magazines to the STANAG variant it may reduce the character count for inventory database entries, thus decreasing the chances of the inventory field exceeding the allowed character count, deleting items, players losing items, and then leaving players/admins wondering what happened; waste of time. Further, since G36 magazines are not an item which the traders buy/sell, players can at least buy/sell the STANAG ammo they do find with the the G36 weapon.
