### PR TITLE
Fix AI from being counted as zeds.

### DIFF
--- a/SQF/dayz_code/compile/player_spawnCheck.sqf
+++ b/SQF/dayz_code/compile/player_spawnCheck.sqf
@@ -31,10 +31,12 @@ dayz_maxGlobalZombies = dayz_maxGlobalZombiesInit;
 	if(isPlayer _x) then {
 		dayz_maxGlobalZombies = dayz_maxGlobalZombies + dayz_maxGlobalZombiesIncrease;
 	} else {
-		if (local _x) then {
-			dayz_spawnZombies = dayz_spawnZombies + 1;
+		if (_x isKindOf "zZombie_Base") then {
+			if (local _x) then {
+				dayz_spawnZombies = dayz_spawnZombies + 1;
+			};
+			dayz_CurrentZombies = dayz_CurrentZombies + 1;
 		};
-		dayz_CurrentZombies = dayz_CurrentZombies + 1;
 	};
 } foreach _players;
 


### PR DESCRIPTION
As it was, the loop simply counted everything within a certain radius
that was not a player but is a CAManBase as a zombie.

https://github.com/vbawol/DayZ-Epoch/issues/1029
