### PR TITLE
Keep safe/lockbox vars server side until needed

### DIFF
--- a/SQF/dayz_code/compile/player_unlockVault.sqf
+++ b/SQF/dayz_code/compile/player_unlockVault.sqf
@@ -65,10 +65,16 @@ if ((_ownerID == dayz_combination) or (_ownerID == dayz_playerUID)) then {
 			[player,"tentpack",0,false] call dayz_zombieSpeak;
 			sleep 5;
 
-			_weapons = 		_obj getVariable["WeaponCargo",[]];
-			_magazines = 	_obj getVariable["MagazineCargo",[]];
-			_backpacks = 	_obj getVariable["BackpackCargo",[]];
-	
+			PVDZE_obj_localVars = [player, _obj, ["WeaponCargo", "MagazineCargo", "BackpackCargo"]];
+			publicVariableServer "PVDZE_obj_localVars";
+			
+			PVDZE_localVarsResult = nil;
+			waitUntil {sleep 1; !isNil "PVDZE_localVarsResult"};
+
+			_weapons = if (typeName (PVDZE_localVarsResult select 0) == "ARRAY") then { (PVDZE_localVarsResult select 0) } else { [] };
+			_magazines = if (typeName (PVDZE_localVarsResult select 1) == "ARRAY") then { (PVDZE_localVarsResult select 1) } else { [] };
+			_backpacks = if (typeName (PVDZE_localVarsResult select 2) == "ARRAY") then { (PVDZE_localVarsResult select 2) } else { [] };
+
 			_holder = createVehicle [_unlockedClass,_pos,[], 0, "CAN_COLLIDE"];
 			if ((isNull _holder) or (isNil "_holder")) then {
 				_holder = createVehicle [_unlockedClass,_pos,[], 0, "CAN_COLLIDE"];

--- a/SQF/dayz_code/init/publicEH.sqf
+++ b/SQF/dayz_code/init/publicEH.sqf
@@ -62,6 +62,8 @@ if (isServer) then {
 	"PVDZE_obj_Trade"		addPublicVariableEventHandler {(_this select 1) spawn server_tradeObj};
 	"PVDZE_plr_TradeMenu"	addPublicVariableEventHandler {(_this select 1) spawn server_traders};
 	"PVDZE_plr_DeathB"		addPublicVariableEventHandler {(_this select 1) spawn server_deaths};
+
+	"PVDZE_obj_localVars" addPublicVariableEventHandler {(_this select 1) spawn server_getLocalObjVars};
 };
 
 //Client only

--- a/SQF/dayz_server/init/server_functions.sqf
+++ b/SQF/dayz_server/init/server_functions.sqf
@@ -884,3 +884,34 @@ server_spawnCleanAnimals = {
 		diag_log (format["CLEANUP: Deleted %1 Animals out of %2",_delQtyAnimal,_qty]);
 	};
 };
+
+/*
+server_getLocalObjVars
+Gets local vars from a target objects and pushing results back to client
+Eg.
+
+PVDZE_obj_localVars = [player, _obj, ["WeaponCargo", "MagazineCargo", "BackpackCargo"]];
+publicVariableServer "PVDZE_obj_localVars";
+
+PVDZE_localObjVarsResult = nil;
+waitUntil {sleep 1; !isNil "PVDZE_localObjVarsResult"};
+*/
+server_getLocalObjVars = {
+	private ["_player", "_obj", "_vars", "_vals"];
+
+	_player = _this select 0;
+	_obj = _this select 1;
+	_vars = _this select 2;
+	
+	if (typeName _vars != "ARRAY") then {
+		_vars = [_vars];
+	};
+
+	_vals = [];
+	{
+		_vals = _vals + [_obj getVariable [_x, false]];
+	} forEach _vars;
+
+	PVDZE_localVarsResult = _vals;
+	(owner _player) publicVariableClient "PVDZE_localVarsResult";
+};

--- a/SQF/dayz_server/system/server_monitor.sqf
+++ b/SQF/dayz_server/system/server_monitor.sqf
@@ -158,9 +158,9 @@ if (isServer and isNil "sm_done") then {
 			if (count _intentory > 0) then {
 				if (_type in DZE_LockedStorage) then {
 					// Fill variables with loot
-					_object setVariable ["WeaponCargo", (_intentory select 0), true];
-					_object setVariable ["MagazineCargo", (_intentory select 1), true];
-					_object setVariable ["BackpackCargo", (_intentory select 2), true];
+					_object setVariable ["WeaponCargo", (_intentory select 0)];
+					_object setVariable ["MagazineCargo", (_intentory select 1)];
+					_object setVariable ["BackpackCargo", (_intentory select 2)];
 				} else {
 
 					//Add weapons


### PR DESCRIPTION
The arrays for safes/lockboxes are kept on the server and when a client
goes to open the safe, a PV is sent to the server requesting the arrays.
Server sends info back.
