### PR TITLE
Update server_functions.sqf

### DIFF
--- a/SQF/dayz_server/init/server_functions.sqf
+++ b/SQF/dayz_server/init/server_functions.sqf
@@ -560,7 +560,7 @@ server_getDiff =	{
 		_vNew = _vNew + _vOld;
 		_object getVariable[(_variable + "_CHK"),_vNew];
 	} else {
-		_result = _vNew - _vOld;
+		_result = _vNew;
 		_object setVariable[(_variable + "_CHK"),_vNew];
 	};
 	_result


### PR DESCRIPTION
If **__result = _vNew - _vOld**_ then _result is returned 0; (since ex: 20-20 = _result)
That returned value is set to the variable that is sent to the database in server_playerSync.sqf.
So the stats gets update to 0. Should be the new value instead.
Thanks also to infistar for sorting this out with me.
Based on : https://github.com/vbawol/DayZ-Epoch/issues/1268
