### PR TITLE
UI Update - Graphical and code changes

### DIFF
--- a/SQF/dayz_code/compile/player_updateGui.sqf
+++ b/SQF/dayz_code/compile/player_updateGui.sqf
@@ -1,6 +1,122 @@
-private ["_display","_ctrlBlood","_ctrlBleed","_bloodVal","_humanityName","_ctrlFood","_ctrlThirst","_thirstVal","_foodVal","_ctrlTemp","_tempVal","_combatVal","_array","_ctrlEar","_ctrlEye","_ctrlCombat","_ctrlFracture","_visualText","_visual","_audibleText","_audible","_blood","_thirstLvl","_foodLvl","_tempImg","_thirst","_food","_temp","_bloodLvl","_tempLvl","_color","_string","_humanity","_size","_friendlies","_charID","_rcharID","_rfriendlies","_rfriendlyTo","_distance","_targetControl"];
+private ["_display","_ctrlBlood","_ctrlBleed","_bloodVal","_humanityName","_ctrlFood","_ctrlThirst","_thirstVal","_foodVal","_ctrlTemp","_tempVal","_combatVal","_array","_ctrlEar","_ctrlEye","_ctrlCombat","_ctrlFracture","_visualText","_visual","_audibleText","_audible","_blood","_thirstLvl","_foodLvl","_tempImg","_thirst","_food","_temp","_bloodLvl","_tempLvl","_color","_string","_humanity","_size","_friendlies","_charID","_rcharID","_rfriendlies","_rfriendlyTo","_distance","_targetControl","_combattimeout","_timeleft"];
 disableSerialization;
+if(Dayz_Dark_UI) then {
 
+_foodVal   =  (dayz_hunger / SleepFood);
+_thirstVal =  (dayz_thirst / SleepWater);
+
+if (uiNamespace getVariable ["DZ_displayUI", 0] == 1) exitWith {
+	_array = [_foodVal,_thirstVal];
+	_array
+};
+
+if(dayz_combat == 1) then {
+	_combattimeout = player getVariable["combattimeout",0];
+	_timeleft = _combattimeout - time;
+	_combatVal = (_timeleft/30);
+}
+else {
+_combatVal = 0;
+};
+
+
+_tempVal   =  ((dayz_temperatur - dayz_temperaturmin)/(dayz_temperaturmax - dayz_temperaturmin));	// Normalise to [0,1]
+_audible   =  (dayz_disAudial / 50);
+_visual    =  (dayz_disVisual / 100);
+_bloodVal  =  r_player_blood / r_player_bloodTotal;
+
+_display = uiNamespace getVariable 'DAYZ_GUI_display';
+
+_ctrlBlood = 	_display displayCtrl 1300;
+_ctrlBleed = 	_display displayCtrl 1303;
+_ctrlFood = 	_display displayCtrl 1301;
+_ctrlThirst = 	_display displayCtrl 1302;
+_ctrlTemp 	= 	_display displayCtrl 1306;					//TeeChange
+_ctrlEar = 		_display displayCtrl 1304;
+_ctrlEye = 		_display displayCtrl 1305;
+//_ctrlHumanity = _display displayCtrl 1207;
+_ctrlCombat = _display displayCtrl 1307;
+_ctrlFracture = 	_display displayCtrl 1203;
+
+//Food/Water/Blood
+_ctrlBlood ctrlSetTextColor 	[(1 - _bloodVal),(1 - _bloodVal),(1 - _bloodVal), 0.5];
+_ctrlFood ctrlSetTextColor 		[ _foodVal,_foodVal,_foodVal, 0.5];
+_ctrlThirst ctrlSetTextColor 	[ _thirstVal, _thirstVal, _thirstVal, 0.5];
+_ctrlTemp ctrlSetTextColor 		[(1 - _tempVal),(1 - _tempVal), (1 - _tempVal), 0.5];	// Color ranges from iceblue (cold) to red (hot)
+_ctrlCombat ctrlSetTextColor	[ _combatVal, _combatVal, _combatVal, 0.5];
+_ctrlEye ctrlSetTextColor       [ _visual, _visual, _visual, 0.5];
+_ctrlEar ctrlSetTextColor       [ _audible, _audible, _audible, 0.5];   
+/*
+	Blood: round((r_player_blood / 2) / 1000) = _bloodLvl (6 = full, 1 = empty)
+	Thirst: round(_thirstVal / 0.25) = _thirstLvl (4 = full, 0 = empty)
+	Hunger: round(_foodVal / 0.25) = _foodLvl (4 = full, 0 = empty)
+	Temp: round(dayz_temperatur) = tempLvl (>= 36 = full <= 28 = empty)
+*/
+/*
+diag_log format["DEBUG: bloodlvl: %1 r_player_blood: %2 bloodval: %3",_bloodLvl, r_player_blood, _bloodVal];
+diag_log format["DEBUG: thirstlvl: %1 dayz_thirst: %2 thirstval: %3",_thirstLvl, dayz_thirst, _thirstVal];
+diag_log format["DEBUG: foodlvl: %1 dayz_hunger: %2 foodval: %3",_foodLvl, dayz_hunger, _foodVal];
+diag_log format["DEBUG: templvl: %1 dayz_temperatur: %2 tempval: %3",_tempLvl, dayz_temperatur, _tempVal];
+*/
+
+//left naming conventions the same in case other files are re-introduced at a later time
+_blood = "\z\addons\dayz_code\gui\status_blood_inside_6_ca.paa";
+_thirst = "\z\addons\dayz_code\gui\status_thirst_inside_4_ca.paa";
+_food = "\z\addons\dayz_code\gui\status_food_inside_4_ca.paa";
+_temp = "\z\addons\dayz_code\gui\status_temp_4_ca.paa";
+_visualtext = "\z\addons\dayz_code\gui\status_eye_ca.paa";
+_audibletext = "\z\addons\dayz_code\gui\status_ear_ca.paa";
+
+_ctrlBlood ctrlSetText _blood;
+_ctrlThirst ctrlSetText _thirst;
+_ctrlFood ctrlSetText _food;
+_ctrlTemp ctrlSetText _temp;
+_ctrlEye ctrlSetText _visualtext;
+_ctrlEar ctrlSetText _audibletext;
+
+/*
+	Fracture:
+*/
+if (!canStand player) then {
+	if (!(ctrlShown _ctrlFracture)) then {
+		r_fracture_legs = true;
+		_ctrlFracture ctrlShow true;
+	};
+};
+
+/*
+	Flashing:
+*/
+if (_combatVal == 1) then {
+	_ctrlCombat call player_guiControlFlash;
+};
+
+if (_bloodVal < 0.2) then {
+	_ctrlBlood call player_guiControlFlash;
+};
+
+if (_thirstVal > 0.8) then {
+	_ctrlThirst call player_guiControlFlash;
+};
+
+if (_foodVal > 0.8) then {
+	_ctrlFood call player_guiControlFlash;
+};
+
+if (_tempVal < 0.2) then {	//TeeChange
+	_ctrlTemp call player_guiControlFlash;
+} else {
+	_ctrlTemp ctrlShow true;
+};
+
+if (r_player_injured) then {
+	_ctrlBleed call player_guiControlFlash;
+};
+
+
+
+}
+else {
 _foodVal = 		1 - (dayz_hunger / SleepFood);
 _thirstVal = 	1 - (dayz_thirst / SleepWater);
 _tempVal 	= 	1 - ((dayz_temperatur - dayz_temperaturmin)/(dayz_temperaturmax - dayz_temperaturmin));	// Normalise to [0,1]
@@ -134,6 +250,9 @@ if (_tempVal > 0.8) then {	//TeeChange
 
 if (r_player_injured) then {
 	_ctrlBleed call player_guiControlFlash;
+};
+
+
 };
 
 /*

--- a/SQF/dayz_code/init/variables.sqf
+++ b/SQF/dayz_code/init/variables.sqf
@@ -188,6 +188,7 @@ dayz_locationsActive = [];
 Dayz_GUI_R = 0.38; // 0.7
 Dayz_GUI_G = 0.63; // -0.63
 Dayz_GUI_B = 0.26; // -0.26
+Dayz_Dark_UI = true;
 
 //Player self-action handles
 dayz_resetSelfActions = {


### PR DESCRIPTION
UI Update - Graphical and code changes …
Changed player_updateGui.sqf with an update to how the UI elements are
loaded. Changed all status icons to use the full value so no more fading
icons. Also changed the colors from red/green setup to a black and white
setup. All icons start off as black if the value is optimal, (full
blood, full food/drink, temperature, out of combat, seen, heard), then
progress continually towards white as the player loses blood, gets
hungry, etc. This was done to make the differences between full and
empty more drastic as the current method starts off with obvious icons
that slowly fade. If player is color blind, there have been reported
issues of the two colors showing up as similar shades of gray. For those
that are not CB the elements currently become less obvious in the user's
peripheral until they begin flashing. Changes also made to variables.sqf
to add the ability to turn this feature on/off:
Dayz_Dark_UI = true;
Sets UI to new darker theme. Turned off by setting the value to false.
More info can be found here:
http://epochmod.com/forum/index.php?/topic/13654-proposed-ui-change/#entry97677
https://github.com/vbawol/DayZ-Epoch/issues/1383
