### PR TITLE
Additional update to UI

### DIFF
--- a/SQF/dayz_code/compile/player_updateGui.sqf
+++ b/SQF/dayz_code/compile/player_updateGui.sqf
@@ -87,32 +87,49 @@ if (!canStand player) then {
 /*
 	Flashing:
 */
-if (_combatVal == 1) then {
-	_ctrlCombat call player_guiControlFlash;
+_ctrl_Array=[];
+if (_combatVal > 0) then {
+	_ctrl_Array=_ctrl_Array + [_ctrlCombat];	 
+}else {
+	_ctrlCombat ctrlShow true;
 };
 
-if (_bloodVal < 0.2) then {
-	_ctrlBlood call player_guiControlFlash;
+
+if (_bloodVal < 0.4) then {
+	_ctrl_Array=_ctrl_Array + [_ctrlBlood];
+}else {
+	_ctrlBlood ctrlShow true;
 };
+
 
 if (_thirstVal > 0.8) then {
-	_ctrlThirst call player_guiControlFlash;
+	_ctrl_Array=_ctrl_Array + [_ctrlThirst];
+}else {
+	_ctrlThirst ctrlShow true;
 };
 
 if (_foodVal > 0.8) then {
-	_ctrlFood call player_guiControlFlash;
+	_ctrl_Array=_ctrl_Array + [_ctrlFood];
+}else {
+	_ctrlFood ctrlShow true;
 };
 
 if (_tempVal < 0.2) then {	//TeeChange
-	_ctrlTemp call player_guiControlFlash;
+	_ctrl_Array=_ctrl_Array + [_ctrlTemp];
 } else {
 	_ctrlTemp ctrlShow true;
 };
 
 if (r_player_injured) then {
-	_ctrlBleed call player_guiControlFlash;
+	_ctrl_Array=_ctrl_Array + [_ctrlBleed];
+}else {
+	_ctrlBleed ctrlShow false;
 };
 
+if((count _ctrl_Array) > 0) then
+{
+_ctrl_Array call player_guiControlFlash;
+};
 
 
 }
@@ -226,30 +243,48 @@ if (!canStand player) then {
 /*
 	Flashing:
 */
+_ctrl_Array=[];
 if (_combatVal == 0) then {
-	_ctrlCombat call player_guiControlFlash;
+	_ctrl_Array=_ctrl_Array + [_ctrlCombat];	 
+}else {
+	_ctrlCombat ctrlShow true;
 };
 
-if (_bloodVal < 0.2) then {
-	_ctrlBlood call player_guiControlFlash;
+
+if (_bloodVal < 0.4) then {
+	_ctrl_Array=_ctrl_Array + [_ctrlBlood];
+}else {
+	_ctrlBlood ctrlShow true;
 };
+
 
 if (_thirstVal < 0.2) then {
-	_ctrlThirst call player_guiControlFlash;
+	_ctrl_Array=_ctrl_Array + [_ctrlThirst];
+}else {
+	_ctrlThirst ctrlShow true;
 };
 
 if (_foodVal < 0.2) then {
-	_ctrlFood call player_guiControlFlash;
+	_ctrl_Array=_ctrl_Array + [_ctrlFood];
+}else {
+	_ctrlFood ctrlShow true;
 };
 
 if (_tempVal > 0.8) then {	//TeeChange
-	_ctrlTemp call player_guiControlFlash;
+	_ctrl_Array=_ctrl_Array + [_ctrlTemp];
 } else {
 	_ctrlTemp ctrlShow true;
 };
 
 if (r_player_injured) then {
-	_ctrlBleed call player_guiControlFlash;
+	_ctrl_Array=_ctrl_Array + [_ctrlBleed];
+}else {
+	_ctrlBleed ctrlShow false;
+};
+
+if((count _ctrl_Array) > 0) then
+{
+_ctrl_Array call player_guiControlFlash;
 };
 
 

--- a/SQF/dayz_code/init/compiles.sqf
+++ b/SQF/dayz_code/init/compiles.sqf
@@ -278,15 +278,15 @@ if (!isDedicated) then {
 		};
 	};
 
-	player_guiControlFlash = 	{
-		private["_control"];
-		_control = _this;
-		if (ctrlShown _control) then {
-			_control ctrlShow false;
-		} else {
-			_control ctrlShow true;
-		};
-	};
+    player_guiControlFlash =     {
+        private["_control"];
+        _control = _this;
+        if (ctrlShown (_control select 0)) then {
+            {_x ctrlShow false} foreach _control;
+        } else {
+            {_x ctrlShow true} foreach _control;
+        };
+    };
 	
 	gearDialog_create = {
 		private ["_i","_dialog"];


### PR DESCRIPTION
Changed routines so that all icons flash at the same time. Instead of
making several individual calls to player_guiControlFlash any icon that
needs to have flashing turned on is added to an array and then, as long
as that array is not empty,  it is passed to the function. The function
was changed to deal with an array and whichever item is array select 0
has its show state determine what all the others should be. If its on,
then all others in array are turned off with it. This will sync all flashing icons.
Also, added a fix for _bloodVal. With current red/green icon set, if the
player has less than 3000 blood the value rounds down to 1 
_bloodLvl =1.5= round((3000/ 2) / 1000);
so that status_blood_inside_1_ca.paa is used, (which is an empty picture). This
means the old line
if (_bloodVal < 0.2) then {
passes along an empty picture to flash. I changed this value to .4 so
that between 3000 and 5000 blood, it still uses that last sliver picture
but that one now flashes to alert player to lower blood levels.
