### PR TITLE
Fix nearestObjects position error

### DIFF
--- a/SQF/dayz_server/compile/server_playerSync.sqf
+++ b/SQF/dayz_server/compile/server_playerSync.sqf
@@ -203,10 +203,9 @@ if (_characterID != "0") then {
 		};
 		
 		// Force gear updates for nearby vehicles/tents
-		_pos = _this select 0;
 		{
 			[_x, "gear"] call server_updateObject;
-		} count nearestObjects [_pos, dayz_updateObjects, 10];
+		} count (nearestObjects [_charPos, dayz_updateObjects, 10]);
 		//[_charPos] call server_updateNearbyObjects;
 
 		//Reset timer


### PR DESCRIPTION
 6:36:48 Error in expression <ear"] call server_updateObject;
} count nearestObjects [_pos, dayz_updateObjects>
 6:36:48   Error position: <nearestObjects [_pos, dayz_updateObjects>
 6:36:48   Error 0 elements provided, 3 expected
 6:36:48 File z\addons\dayz_server\compile\server_playerSync.sqf, line 209