### PR TITLE
snap building plotpole / infinite drag fix

### DIFF
--- a/SQF/dayz_code/Configs/CfgExtra/snappoints.hpp
+++ b/SQF/dayz_code/Configs/CfgExtra/snappoints.hpp
@@ -183,6 +183,7 @@ class SnapBuilding {
 		{-1.73926,0.05,0,"Bottom"}
 		};
 	};
+	class WoodStairs_DZ: Stairs_DZE {};
 	class WoodStairs_Preview_DZ: Stairs_DZE {};
 	class WoodStairsSans_Preview_DZ: Stairs_DZE {};
 	class WoodStairsSans_DZ: Stairs_DZE {};
@@ -203,6 +204,7 @@ class SnapBuilding {
 	class WoodSmallWallWin_DZ: WoodSmall_DZE {};
 	class Land_DZE_WoodDoor: WoodSmall_DZE {};
 	class Land_DZE_WoodDoorLocked: WoodSmall_DZE {};
+	class WoodDoor_Preview_DZ: WoodSmall_DZE{};
 	
 	class WoodLarge_DZE: FloorsWallsStairs { //Large wood walls
 		points[] = {

--- a/SQF/dayz_code/actions/player_build2.sqf
+++ b/SQF/dayz_code/actions/player_build2.sqf
@@ -385,6 +385,32 @@ if (isClass (configFile >> "SnapBuilding" >> _classname)) then {
 			detach _objectHelper;
 			deleteVehicle _objectHelper;
 		};
+		
+		if(_IsNearPlot == 0) then {
+			_findNearestPoles = nearestObjects [_objectHelper, ["Plastic_Pole_EP1_DZ"], 30];
+			_nearestPole = _findNearestPoles select 0;
+			_objectHelperPos = getPosATL _objectHelper;
+			if (_objectHelperPos distance _nearestPole < 30) exitWith {
+				_isOk = false; 
+				_cancel = true;
+				_reason = "You cannot enter plot pole area while building is in progress";
+				detach _object;
+				deleteVehicle _object;
+				detach _objectHelper;
+				deleteVehicle _objectHelper;
+			};
+		};
+			
+		
+		if(_location1 distance _objectHelperPos > 10) exitWith {
+			_isOk = false;
+			_cancel = true;
+			_reason = "Object is placed to far away from where you started building (within 10 meters)";
+			detach _object;
+			deleteVehicle _object;
+			detach _objectHelper;
+			deleteVehicle _objectHelper;
+		};
 
 		if(abs(_objHDiff) > 10) exitWith {
 			_isOk = false;


### PR DESCRIPTION
Fixes issue #1424 
Also stops potential griefing if server runs with no plotpole requirements (If player attempts to build an object outside PP area just to run inside and build it).
