### PR TITLE
Fix Maintain Area/Preview not disappearing

### DIFF
--- a/SQF/dayz_code/compile/fn_selfActions.sqf
+++ b/SQF/dayz_code/compile/fn_selfActions.sqf
@@ -866,6 +866,10 @@ if (!isNull cursorTarget && !_inVehicle && !_isPZombie && (player distance curso
 	s_player_SurrenderedGear = -1;
 
 	//Others
+    	player removeAction s_player_maintain_area;
+    	s_player_maintain_area = -1;
+    	player removeAction s_player_maintain_area_preview;
+    	s_player_maintain_area_preview = -1;
 	player removeAction s_player_forceSave;
 	s_player_forceSave = -1;
 	player removeAction s_player_flipveh;


### PR DESCRIPTION
When players would look at a plot pole, they would get the maintain/preview option and if they looked away they would still have it.
