### PR TITLE
Update zombie_generate.sqf

### DIFF
--- a/SQF/dayz_code/compile/zombie_generate.sqf
+++ b/SQF/dayz_code/compile/zombie_generate.sqf
@@ -89,9 +89,15 @@ if ((dayz_spawnZombies < _maxControlledZombies) && (dayz_CurrentNearByZombies < 
 			_lootType = configFile >> "CfgVehicles" >> _type >> "zombieLoot";
 			if (isText _lootType) then {
 				_array = [];
-				{
-					_array set [count _array, _x select 0]
-				} forEach getArray (configFile >> "cfgLoot" >> getText(_lootType));
+				if (DZE_MissionLootTable) then {
+					{
+						_array set [count _array, _x select 0] 
+					} forEach getArray (missionConfigFile >> "cfgLoot" >> getText(_lootType));
+				} else {
+					{
+						_array set [count _array, _x select 0] 
+					} forEach getArray (configFile >> "cfgLoot" >> getText(_lootType));
+				};
 				if (count _array > 0) then {
 					_index = dayz_CLBase find getText(_lootType);
 					_weights = dayz_CLChances select _index;


### PR DESCRIPTION
Should fix: 

Error in expression <tNumber(configFile >> "CfgMagazines" >> _loot >> "count");
if(_loot_count>1) the>
  Error position: <_loot >> "count");
if(_loot_count>1) the>
  Error Undefined variable in expression: _loot
File z\addons\dayz_code\compile\zombie_generate.sqf, line 100
Error in expression <CLChances select _index;
_loot = _array select (_weights select (floor(random (c>
  Error position: <select (_weights select (floor(random (c>
  Error Zero divisor
File z\addons\dayz_code\compile\zombie_generate.sqf, line 98

when using DZE_MissionLootTable = true;
Fix was found on the epochmod.com forums.
