### PR TITLE
darkUI fix

### DIFF
--- a/SQF/dayz_code/system/player_spawn_2.sqf
+++ b/SQF/dayz_code/system/player_spawn_2.sqf
@@ -125,6 +125,10 @@ while {true} do {
 	//Hunger Effect
 	_foodVal = 		dayz_statusArray select 0;
 	_thirstVal = 	dayz_statusArray select 1;
+	if(Dayz_Dark_UI) then {
+	_foodVal = 1 - (dayz_hunger / SleepFood);
+	_thirstVal = 1 - (dayz_thirst / SleepWater);
+	};
 	if (_thirstVal <= 0) then {
 		_result = r_player_blood - 10;
 		if (_result < 0) then {


### PR DESCRIPTION
In player_updateGUI.sqf, _foodVal and _thirstVal are calculated differently (values closer to 1 are bad) when Dayz_Dark_UI == true. When Dayz_Dark_UI == false (old system), values closer to 0 are bad. This means that when Dayz_Dark_UI == true, health regenerates when both hunger and thirst are LOW instead of high. This fix compensates by redefining the _foodVal and _thirstVal variables for the old UI system, but a better solution might be to rewrite player_updateGUI.sqf to be more compatible.