### PR TITLE
Fix for fix bypass

### DIFF
--- a/SQF/dayz_code/compile/player_antiWall.sqf
+++ b/SQF/dayz_code/compile/player_antiWall.sqf
@@ -44,22 +44,22 @@ if(_activated) then {
 		};
 		if ((_vehicle emptyPositions "driver") > 0) exitWith {
 			cutText [(localize "STR_EPOCH_ACTIONS_15"), "PLAIN DOWN"];
-			player action ["getInDriver", _vehicle];
+			player moveInDriver _vehicle;
 			DZE_AntiWallCounter = DZE_AntiWallCounter + 1;
 		};
 		if ((_vehicle emptyPositions "gunner") > 0) exitWith {
 			cutText [(localize "STR_EPOCH_ACTIONS_15"), "PLAIN DOWN"];
-			player action ["GetInGunner", _vehicle];
+			player moveInGunner _vehicle;
 			DZE_AntiWallCounter = DZE_AntiWallCounter + 1;
 		};
 		if ((_vehicle emptyPositions "commander") > 0) exitWith {
 			cutText [(localize "STR_EPOCH_ACTIONS_15"), "PLAIN DOWN"];
-			player action ["getInCommander", _vehicle];
+			player moveInCommander _vehicle;
 			DZE_AntiWallCounter = DZE_AntiWallCounter + 1;
 		};
 		if ((_vehicle emptyPositions "cargo") > 0) exitWith {
 			cutText [(localize "STR_EPOCH_ACTIONS_15"), "PLAIN DOWN"];
-			player action ["getInCargo", _vehicle];
+			player moveInCargo _vehicle;
 			DZE_AntiWallCounter = DZE_AntiWallCounter + 1;
 		};
 		// kill player if none of the above are matched


### PR DESCRIPTION
Players can get around this by getting another player to lock the vehicle as they're getting out. The action command only works if the vehicle is unlocked, using the moveInX commands it moves them instantly back in with no animation (better imo) and works if the vehicle is locked.