### PR TITLE
Update Military.hpp

### DIFF
--- a/SQF/dayz_code/Configs/CfgLoot/Buildings/Military.hpp
+++ b/SQF/dayz_code/Configs/CfgLoot/Buildings/Military.hpp
@@ -22,9 +22,9 @@ class MilitarySpecial : Military
 	zombieClass[] =
 	{
 		"z_soldier_heavy",
-		"z_new_worker2",
-		"z_new_worker3",
-		"z_new_worker4"
+		"z_soldier_heavy",
+		"z_soldier",
+		"z_policeman"
 	};
 	lootChance = 0.4;
 	lootGroup = MilitarySpecial;


### PR DESCRIPTION
I changed the spawning zombie typ for the military special loot. I noticed that there are almost only "z_new_worker2-4" zombies in the baracks and got a bit confused. So now we have the military zombies back.