### PR TITLE
Advanced trading fixes/modifications

### DIFF
--- a/SQF/dayz_code/Configs/RscDisplay/advancedTrading.hpp
+++ b/SQF/dayz_code/Configs/RscDisplay/advancedTrading.hpp
@@ -453,6 +453,17 @@ class AdvancedTrading
 			x = 0.63 * safezoneW + safezoneX;
 			y = 0.77 * safezoneH + safezoneY;
 			w = 0.13 * safezoneW;
+			onButtonClick = "[[],0] call epoch_returnChange; ((ctrlParent (_this select 0)) closeDisplay 9000); localize ""STR_EPOCH_PLAYER_307"" call dayz_rollingMessages;";
+			colorBackground[] =  {1,1,1,1};
+			color[] = {0,0,0,1};
+			text = $STR_EPOCH_PLAYER_306;
+		};
+		class ZSC_RscButtonMenu_AT29: AT_Zupa_BlueButton
+		{
+			idc = -1;
+			x = 0.63 * safezoneW + safezoneX;
+			y = 0.80 * safezoneH + safezoneY;
+			w = 0.13 * safezoneW;
 			onButtonClick = "((ctrlParent (_this select 0)) closeDisplay 9000);";
 			colorBackground[] =  {1,1,1,1};
 			color[] = {0,0,0,1};

--- a/SQF/dayz_code/actions/AdvancedTrading/functions/z_at_buyItems.sqf
+++ b/SQF/dayz_code/actions/AdvancedTrading/functions/z_at_buyItems.sqf
@@ -1,5 +1,5 @@
 private ["_magazinesToBuy", "_weaponsToBuy", "_backpacksToBuy", "_toolsToBuy", "_sidearmToBuy", "_primaryToBuy", "_priceToBuy"
-,"_enoughMoney", "_myMoney", "_canBuy", "_moneyInfo","_count","_success","_backpack","_toolClasses","_itemsToLog","_tcost","_index"
+,"_enoughMoney", "_myMoney", "_canBuy", "_moneyInfo","_count","_success","_backpack","_toolClasses","_itemsToLog","_tcost"
 ];
 
 _magazinesToBuy = 0;
@@ -14,233 +14,230 @@ _priceToBuy = 0;
 _toolClasses = [];
 _itemsToLog = [[],[],[],"buy"];
 
-_index = count (Z_BuyingArray) - 1;
-if (_index > -1) then {
-	if (Z_SingleCurrency) then {
-		{
-			if( _x select 1 == "trade_weapons")then{
-				_parentClasses =  [(configFile >> "CfgWeapons" >> (_x select 0)),true] call BIS_fnc_returnParents;
-				if( 'ItemCore' in _parentClasses || 'Binocular' in _parentClasses) then {
-					_toolsToBuy = _toolsToBuy + (_x select 9);
-					_toolClasses set [count _toolClasses,(_x select 0)];
-				} else {
-					_weaponsToBuy = _weaponsToBuy + (_x select 9);
-					if('PistolCore' in _parentClasses)then {
-						_sidearmToBuy = _sidearmToBuy + (_x select 9);
-					} else {
-						_primaryToBuy = _primaryToBuy + (_x select 9); // _ammount
-					};
-				};
-				_priceToBuy	= _priceToBuy + ((_x select 9)*(_x select 2));
-			};
-			if( _x select 1 == "trade_items")then{
-				_magazinesToBuy = _magazinesToBuy + (_x select 9) ;
-				_priceToBuy	= _priceToBuy + ((_x select 9)*(_x select 2));
-			};
-			if( _x select 1 == "trade_backpacks")then{
-				_backpacksToBuy = _backpacksToBuy + (_x select 9) ;
-				_priceToBuy	= _priceToBuy + ((_x select 9)*(_x select 2)); // _price * _amount
-			};
-			if((_x select 1) in ["trade_any_vehicle", "trade_any_vehicle_free", "trade_any_vehicle_old", "trade_any_bicycle", "trade_any_bicycle_old", "trade_any_boat", "trade_any_boat_old"])then{
-				_vehiclesToBuy = _vehiclesToBuy + (_x select 9) ;
-				_priceToBuy	= _priceToBuy + ((_x select 9)*(_x select 2)); // _price * _amount
-			};
-			_itemsToLog set [0, (_itemsToLog select 0) + [_x select 0]];
-			_itemsToLog set [1, (_itemsToLog select 1) + [_x select 9]];
-			_itemsToLog set [2, (_itemsToLog select 2) + [((_x select 9)*(_x select 2))]];
-		} count Z_BuyingArray;
-	} else {
-		{
-			if( _x select 1 == "trade_weapons")then{
-				_parentClasses =  [(configFile >> "CfgWeapons" >> (_x select 0)),true] call BIS_fnc_returnParents;
-				if( 'ItemCore' in _parentClasses || 'Binocular' in _parentClasses) then {
-					_toolsToBuy = _toolsToBuy + (_x select 9);
-					_toolClasses set [count _toolClasses,(_x select 0)];
-				} else {
-					_weaponsToBuy = _weaponsToBuy + (_x select 9);
-					if('PistolCore' in _parentClasses)then {
-						_sidearmToBuy = _sidearmToBuy + (_x select 9);
-					} else {
-						_primaryToBuy = _primaryToBuy + (_x select 9);
-					};
-				};
-				_priceToBuy	= _priceToBuy + ((_x select 11)*(_x select 2)*(_x select 9)); // _worth * _price * _amount
-			};
-			if( _x select 1 == "trade_items")then{
-				_magazinesToBuy = _magazinesToBuy + (_x select 9) ;
-				_priceToBuy	= _priceToBuy + ((_x select 11) *(_x select 2)*(_x select 9));
-			};
-			if( _x select 1 == "trade_backpacks")then{
-				_backpacksToBuy = _backpacksToBuy + (_x select 9) ;
-				_priceToBuy	= _priceToBuy + ((_x select 11)*(_x select 2)*(_x select 9));
-			};
-			if((_x select 1) in ["trade_any_vehicle", "trade_any_vehicle_free", "trade_any_vehicle_old", "trade_any_bicycle", "trade_any_bicycle_old", "trade_any_boat", "trade_any_boat_old"])then{
-				_vehiclesToBuy = _vehiclesToBuy + (_x select 9) ;
-				_priceToBuy	= _priceToBuy + ((_x select 11)*(_x select 2)*(_x select 9));
-			};
-			_itemsToLog set [0, (_itemsToLog select 0) + [_x select 0]];
-			_itemsToLog set [1, (_itemsToLog select 1) + [_x select 9]];
-			_itemsToLog set [2, (_itemsToLog select 2) + [((_x select 11)*(_x select 2)*(_x select 9))]];
-		} count Z_BuyingArray;
-	};
+if (count Z_BuyingArray < 1) exitWith { systemChat localize "STR_EPOCH_TRADE_BUY_NO_ITEMS"; };
 
-	_canBuy = [_weaponsToBuy,_magazinesToBuy,_backpacksToBuy,_toolsToBuy, _sidearmToBuy, _primaryToBuy,_vehiclesToBuy,_toolClasses] call Z_allowBuying;
-
-	_myMoney = player getVariable[Z_MoneyVariable,0];
-
-	_enoughMoney = false;
-
-	_moneyInfo = [false, [], [], [], 0];
-
-	if (Z_SingleCurrency) then {
-		if (_myMoney >= _priceToBuy) then {
-			_enoughMoney = true;
-		} else {
-			_enoughMoney = false;
-		};
-	} else {
-		_moneyInfo = _priceToBuy call Z_canAfford;
-		_enoughMoney = _moneyInfo select 0;
-	};
-
-	if(_enoughMoney) then {
-		if(_canBuy) then {
-			_buyVehicle = {
-				private "_location";
-				_part_out = _this select 0;
-				_buyingType = _this select 1;
-				_keySelected = "0";
-				_isKeyOK= false;
-				if (_buyingType in ["trade_any_vehicle_free", "trade_any_bicycle", "trade_any_bicycle_old"]) then {
-					_isKeyOK = true;
-				} else {
-					_keyColor = ["Green","Red","Blue","Yellow","Black"] call BIS_fnc_selectRandom;
-					_keyNumber = (floor(random 2500)) + 1;
-					_keySelected = format["ItemKey%1%2",_keyColor,_keyNumber];
-					_isKeyOK = 	isClass(configFile >> "CfgWeapons" >> _keySelected);
-				};
-				if (!_isKeyOK) exitWith {localize "str_epoch_player_107" call dayz_rollingMessages; "";};
-				_activatingPlayer = player;
-				_dir = round(random 360);
-				_helipad = nearestObjects [player, ["HeliHCivil","HeliHempty"], 100];
-				
-				if(count _helipad > 0) then {
-					_location = (getPosATL (_helipad select 0));
-				} else {
-					_location = [([player] call FNC_GetPos),0,20,1,0,2000,0] call BIS_fnc_findSafePos;
-				};
-
-				_veh = createVehicle ["Sign_arrow_down_large_EP1", _location, [], 0, "CAN_COLLIDE"];
-				_location = ([_veh] call FNC_GetPos);
-				
-				if (_buyingType in ["trade_any_vehicle_free", "trade_any_bicycle", "trade_any_bicycle_old"]) then {
-					PVDZE_veh_Publish2 = [_veh,[_dir,_location],_part_out,true,"0",_activatingPlayer];
-				} else {
-					PVDZE_veh_Publish2 = [_veh,[_dir,_location],_part_out,false,_keySelected,_activatingPlayer];
-				};
-				publicVariableServer  "PVDZE_veh_Publish2";
-				_keySelected;
-			};
-			systemChat localize "STR_EPOCH_PLAYER_105";
-
-			closeDialog 2;
-
-			if(Z_SellingFrom == 0) then { //backpack
-				_backpack = unitBackpack player;
-				systemChat format[localize "STR_EPOCH_TRADE_IN_BACKPACK",count (Z_BuyingArray)];
-				{
-					if( _x select 1 == "trade_weapons")then{
-						_backpack addWeaponCargoGlobal [_x select 0, _x select 9];
-					};
-					if( _x select 1 == "trade_items")then{
-						_backpack addMagazineCargoGlobal  [_x select 0, _x select 9];
-					};				
-					if((_x select 1) in ["trade_any_vehicle", "trade_any_vehicle_free", "trade_any_vehicle_old", "trade_any_bicycle", "trade_any_bicycle_old", "trade_any_boat", "trade_any_boat_old"])then{
-						_item2Add = [(_x select 0), (_x select 1)] call _buyVehicle;
-						if (_item2Add != "0") then {
-							_backpack addWeaponCargoGlobal  [_item2Add, 1];
-						};
-					};
-				} count Z_BuyingArray;
-			};
-
-			if(Z_SellingFrom == 1)then{ //vehicle
-				{
-					systemChat format["Adding %1 items in %2",count (Z_BuyingArray), typeOf Z_vehicle];
-					if( _x select 1 == "trade_weapons")then{
-						Z_vehicle addWeaponCargoGlobal [_x select 0, _x select 9];
-					};
-					if( _x select 1 == "trade_items")then{
-						Z_vehicle addMagazineCargoGlobal [_x select 0, _x select 9];
-					};
-					if( _x select 1 == "trade_backpacks")then{
-						Z_vehicle addBackpackCargoGlobal [_x select 0, _x select 9];
-					};
-					if((_x select 1) in ["trade_any_vehicle", "trade_any_vehicle_free", "trade_any_vehicle_old", "trade_any_bicycle", "trade_any_bicycle_old", "trade_any_boat", "trade_any_boat_old"])then{
-						_item2Add = [(_x select 0), (_x select 1)] call _buyVehicle;
-						if (_item2Add != "0") then {
-							Z_vehicle addWeaponCargoGlobal [_item2Add, 1];
-						};
-					};
-				} count Z_BuyingArray;
-			};
-
-			if(Z_SellingFrom == 2)then{ //gear
-				systemChat format["Adding %1 items in gear",count (Z_BuyingArray)];
-				{
-					if( _x select 1 == "trade_weapons") then {
-						_count = 0;
-						while{ _count < (_x select 9)}do{
-							player addWeapon (_x select 0);				
-							_count = _count + 1;
-						};
-					};
-					if( _x select 1 == "trade_items" ) then {
-						_count = 0;
-						while{ _count < (_x select 9)} do {
-							player addMagazine (_x select 0);
-							_count = _count + 1;
-						};
-					};
-					if( _x select 1 == "trade_backpacks")then{
-						player addBackpack (_x select 0);
-					};
-					if((_x select 1) in ["trade_any_vehicle", "trade_any_vehicle_free", "trade_any_vehicle_old", "trade_any_bicycle", "trade_any_bicycle_old", "trade_any_boat", "trade_any_boat_old"])then{
-						_item2Add = [(_x select 0), (_x select 1)] call _buyVehicle;
-						if (_item2Add != "0") then {
-							player addWeapon _item2Add;
-						};
-					};
-				} count Z_BuyingArray;
-			};
-			if (!Z_SingleCurrency) then {
-				_success = [player,_priceToBuy, _moneyInfo] call Z_payDefault;
-				if (_success) then {
-					_tcost = "";
-					_tcost = _priceToBuy call z_calcDefaultCurrencyNoImg;
-					systemChat format[localize "STR_EPOCH_TRADE_BUY_SUCCESS", _tcost];
-				} else {
-					systemChat localize "STR_EPOCH_TRADE_DEBUG";
-				};
+if (Z_SingleCurrency) then {
+	{
+		if( _x select 1 == "trade_weapons")then{
+			_parentClasses =  [(configFile >> "CfgWeapons" >> (_x select 0)),true] call BIS_fnc_returnParents;
+			if( 'ItemCore' in _parentClasses || 'Binocular' in _parentClasses) then {
+				_toolsToBuy = _toolsToBuy + (_x select 9);
+				_toolClasses set [count _toolClasses,(_x select 0)];
 			} else {
-				_success = [player,_priceToBuy] call SC_fnc_removeCoins;
-				if (_success) then {
-					systemChat format[localize "STR_EPOCH_TRADE_SUCCESS_COINS", _priceToBuy, CurrencyName];
+				_weaponsToBuy = _weaponsToBuy + (_x select 9);
+				if('PistolCore' in _parentClasses)then {
+					_sidearmToBuy = _sidearmToBuy + (_x select 9);
 				} else {
-					systemChat localize "STR_EPOCH_TRADE_DEBUG";
+					_primaryToBuy = _primaryToBuy + (_x select 9); // _ammount
 				};
 			};
-			_itemsToLog call Z_logTrade;
-		} else {
-			systemChat localize "STR_EPOCH_TRADE_CONTAINER_FULL";
+			_priceToBuy	= _priceToBuy + ((_x select 9)*(_x select 2));
 		};
-	}else{
-		if( Z_SingleCurrency) then {
-			systemChat format[localize "STR_EPOCH_TRADE_NEED_COINS",_priceToBuy,CurrencyName];
-		} else {
-			systemChat localize "STR_EPOCH_TRADE_NEED_MONEY";
+		if( _x select 1 == "trade_items")then{
+			_magazinesToBuy = _magazinesToBuy + (_x select 9) ;
+			_priceToBuy	= _priceToBuy + ((_x select 9)*(_x select 2));
 		};
+		if( _x select 1 == "trade_backpacks")then{
+			_backpacksToBuy = _backpacksToBuy + (_x select 9) ;
+			_priceToBuy	= _priceToBuy + ((_x select 9)*(_x select 2)); // _price * _amount
+		};
+		if((_x select 1) in ["trade_any_vehicle", "trade_any_vehicle_free", "trade_any_vehicle_old", "trade_any_bicycle", "trade_any_bicycle_old", "trade_any_boat", "trade_any_boat_old"])then{
+			_vehiclesToBuy = _vehiclesToBuy + (_x select 9) ;
+			_priceToBuy	= _priceToBuy + ((_x select 9)*(_x select 2)); // _price * _amount
+		};
+		_itemsToLog set [0, (_itemsToLog select 0) + [_x select 0]];
+		_itemsToLog set [1, (_itemsToLog select 1) + [_x select 9]];
+		_itemsToLog set [2, (_itemsToLog select 2) + [((_x select 9)*(_x select 2))]];
+	} count Z_BuyingArray;
+} else {
+	{
+		if( _x select 1 == "trade_weapons")then{
+			_parentClasses =  [(configFile >> "CfgWeapons" >> (_x select 0)),true] call BIS_fnc_returnParents;
+			if( 'ItemCore' in _parentClasses || 'Binocular' in _parentClasses) then {
+				_toolsToBuy = _toolsToBuy + (_x select 9);
+				_toolClasses set [count _toolClasses,(_x select 0)];
+			} else {
+				_weaponsToBuy = _weaponsToBuy + (_x select 9);
+				if('PistolCore' in _parentClasses)then {
+					_sidearmToBuy = _sidearmToBuy + (_x select 9);
+				} else {
+					_primaryToBuy = _primaryToBuy + (_x select 9);
+				};
+			};
+			_priceToBuy	= _priceToBuy + ((_x select 11)*(_x select 2)*(_x select 9)); // _worth * _price * _amount
+		};
+		if( _x select 1 == "trade_items")then{
+			_magazinesToBuy = _magazinesToBuy + (_x select 9) ;
+			_priceToBuy	= _priceToBuy + ((_x select 11) *(_x select 2)*(_x select 9));
+		};
+		if( _x select 1 == "trade_backpacks")then{
+			_backpacksToBuy = _backpacksToBuy + (_x select 9) ;
+			_priceToBuy	= _priceToBuy + ((_x select 11)*(_x select 2)*(_x select 9));
+		};
+		if((_x select 1) in ["trade_any_vehicle", "trade_any_vehicle_free", "trade_any_vehicle_old", "trade_any_bicycle", "trade_any_bicycle_old", "trade_any_boat", "trade_any_boat_old"])then{
+			_vehiclesToBuy = _vehiclesToBuy + (_x select 9) ;
+			_priceToBuy	= _priceToBuy + ((_x select 11)*(_x select 2)*(_x select 9));
+		};
+		_itemsToLog set [0, (_itemsToLog select 0) + [_x select 0]];
+		_itemsToLog set [1, (_itemsToLog select 1) + [_x select 9]];
+		_itemsToLog set [2, (_itemsToLog select 2) + [((_x select 11)*(_x select 2)*(_x select 9))]];
+	} count Z_BuyingArray;
+};
+
+_canBuy = [_weaponsToBuy,_magazinesToBuy,_backpacksToBuy,_toolsToBuy, _sidearmToBuy, _primaryToBuy,_vehiclesToBuy,_toolClasses] call Z_allowBuying;
+
+_myMoney = player getVariable[Z_MoneyVariable,0];
+
+_enoughMoney = false;
+
+_moneyInfo = [false, [], [], [], 0];
+
+if (Z_SingleCurrency) then {
+	if (_myMoney >= _priceToBuy) then {
+		_enoughMoney = true;
+	} else {
+		_enoughMoney = false;
 	};
 } else {
-	systemChat localize "STR_EPOCH_TRADE_BUY_NO_ITEMS";
+	_moneyInfo = _priceToBuy call Z_canAfford;
+	_enoughMoney = _moneyInfo select 0;
+};
+
+if(_enoughMoney) then {
+	if(_canBuy) then {
+		_buyVehicle = {
+			private "_location";
+			_part_out = _this select 0;
+			_buyingType = _this select 1;
+			_keySelected = "0";
+			_isKeyOK= false;
+			if (_buyingType in ["trade_any_vehicle_free", "trade_any_bicycle", "trade_any_bicycle_old"]) then {
+				_isKeyOK = true;
+			} else {
+				_keyColor = ["Green","Red","Blue","Yellow","Black"] call BIS_fnc_selectRandom;
+				_keyNumber = (floor(random 2500)) + 1;
+				_keySelected = format["ItemKey%1%2",_keyColor,_keyNumber];
+				_isKeyOK = 	isClass(configFile >> "CfgWeapons" >> _keySelected);
+			};
+			if (!_isKeyOK) exitWith {localize "str_epoch_player_107" call dayz_rollingMessages; "";};
+			_activatingPlayer = player;
+			_dir = round(random 360);
+			_helipad = nearestObjects [player, ["HeliHCivil","HeliHempty"], 100];
+			
+			if(count _helipad > 0) then {
+				_location = (getPosATL (_helipad select 0));
+			} else {
+				_location = [([player] call FNC_GetPos),0,20,1,0,2000,0] call BIS_fnc_findSafePos;
+			};
+
+			_veh = createVehicle ["Sign_arrow_down_large_EP1", _location, [], 0, "CAN_COLLIDE"];
+			_location = ([_veh] call FNC_GetPos);
+			
+			if (_buyingType in ["trade_any_vehicle_free", "trade_any_bicycle", "trade_any_bicycle_old"]) then {
+				PVDZE_veh_Publish2 = [_veh,[_dir,_location],_part_out,true,"0",_activatingPlayer];
+			} else {
+				PVDZE_veh_Publish2 = [_veh,[_dir,_location],_part_out,false,_keySelected,_activatingPlayer];
+			};
+			publicVariableServer  "PVDZE_veh_Publish2";
+			_keySelected;
+		};
+		systemChat localize "STR_EPOCH_PLAYER_105";
+
+		closeDialog 2;
+
+		if(Z_SellingFrom == 0) then { //backpack
+			_backpack = unitBackpack player;
+			systemChat format[localize "STR_EPOCH_TRADE_IN_BACKPACK",count (Z_BuyingArray)];
+			{
+				if( _x select 1 == "trade_weapons")then{
+					_backpack addWeaponCargoGlobal [_x select 0, _x select 9];
+				};
+				if( _x select 1 == "trade_items")then{
+					_backpack addMagazineCargoGlobal  [_x select 0, _x select 9];
+				};				
+				if((_x select 1) in ["trade_any_vehicle", "trade_any_vehicle_free", "trade_any_vehicle_old", "trade_any_bicycle", "trade_any_bicycle_old", "trade_any_boat", "trade_any_boat_old"])then{
+					_item2Add = [(_x select 0), (_x select 1)] call _buyVehicle;
+					if (_item2Add != "0") then {
+						_backpack addWeaponCargoGlobal  [_item2Add, 1];
+					};
+				};
+			} count Z_BuyingArray;
+		};
+
+		if(Z_SellingFrom == 1)then{ //vehicle
+			{
+				systemChat format["Adding %1 items in %2",count (Z_BuyingArray), typeOf Z_vehicle];
+				if( _x select 1 == "trade_weapons")then{
+					Z_vehicle addWeaponCargoGlobal [_x select 0, _x select 9];
+				};
+				if( _x select 1 == "trade_items")then{
+					Z_vehicle addMagazineCargoGlobal [_x select 0, _x select 9];
+				};
+				if( _x select 1 == "trade_backpacks")then{
+					Z_vehicle addBackpackCargoGlobal [_x select 0, _x select 9];
+				};
+				if((_x select 1) in ["trade_any_vehicle", "trade_any_vehicle_free", "trade_any_vehicle_old", "trade_any_bicycle", "trade_any_bicycle_old", "trade_any_boat", "trade_any_boat_old"])then{
+					_item2Add = [(_x select 0), (_x select 1)] call _buyVehicle;
+					if (_item2Add != "0") then {
+						Z_vehicle addWeaponCargoGlobal [_item2Add, 1];
+					};
+				};
+			} count Z_BuyingArray;
+		};
+
+		if(Z_SellingFrom == 2)then{ //gear
+			systemChat format["Adding %1 items in gear",count (Z_BuyingArray)];
+			{
+				if( _x select 1 == "trade_weapons") then {
+					_count = 0;
+					while{ _count < (_x select 9)}do{
+						player addWeapon (_x select 0);				
+						_count = _count + 1;
+					};
+				};
+				if( _x select 1 == "trade_items" ) then {
+					_count = 0;
+					while{ _count < (_x select 9)} do {
+						player addMagazine (_x select 0);
+						_count = _count + 1;
+					};
+				};
+				if( _x select 1 == "trade_backpacks")then{
+					player addBackpack (_x select 0);
+				};
+				if((_x select 1) in ["trade_any_vehicle", "trade_any_vehicle_free", "trade_any_vehicle_old", "trade_any_bicycle", "trade_any_bicycle_old", "trade_any_boat", "trade_any_boat_old"])then{
+					_item2Add = [(_x select 0), (_x select 1)] call _buyVehicle;
+					if (_item2Add != "0") then {
+						player addWeapon _item2Add;
+					};
+				};
+			} count Z_BuyingArray;
+		};
+		if (!Z_SingleCurrency) then {
+			_success = [player,_priceToBuy, _moneyInfo] call Z_payDefault;
+			if (_success) then {
+				_tcost = "";
+				_tcost = _priceToBuy call z_calcDefaultCurrencyNoImg;
+				systemChat format[localize "STR_EPOCH_TRADE_BUY_SUCCESS", _tcost];
+			} else {
+				systemChat localize "STR_EPOCH_TRADE_DEBUG";
+			};
+		} else {
+			_success = [player,_priceToBuy] call SC_fnc_removeCoins;
+			if (_success) then {
+				systemChat format[localize "STR_EPOCH_TRADE_SUCCESS_COINS", _priceToBuy, CurrencyName];
+			} else {
+				systemChat localize "STR_EPOCH_TRADE_DEBUG";
+			};
+		};
+		_itemsToLog call Z_logTrade;
+	} else {
+		systemChat localize "STR_EPOCH_TRADE_CONTAINER_FULL";
+	};
+}else{
+	if( Z_SingleCurrency) then {
+		systemChat format[localize "STR_EPOCH_TRADE_NEED_COINS",_priceToBuy,CurrencyName];
+	} else {
+		systemChat localize "STR_EPOCH_TRADE_NEED_MONEY";
+	};
 };

--- a/SQF/dayz_code/actions/AdvancedTrading/functions/z_at_buyItems.sqf
+++ b/SQF/dayz_code/actions/AdvancedTrading/functions/z_at_buyItems.sqf
@@ -1,5 +1,5 @@
 private ["_magazinesToBuy", "_weaponsToBuy", "_backpacksToBuy", "_toolsToBuy", "_sidearmToBuy", "_primaryToBuy", "_priceToBuy"
-,"_enoughMoney", "_myMoney", "_canBuy", "_moneyInfo","_count","_success","_backpack","_toolClasses","_itemsToLog"
+,"_enoughMoney", "_myMoney", "_canBuy", "_moneyInfo","_count","_success","_backpack","_toolClasses","_itemsToLog","_tcost","_index"
 ];
 
 _magazinesToBuy = 0;
@@ -14,226 +14,233 @@ _priceToBuy = 0;
 _toolClasses = [];
 _itemsToLog = [[],[],[],"buy"];
 
-if (Z_SingleCurrency) then {
-	{
-		if( _x select 1 == "trade_weapons")then{
-			_parentClasses =  [(configFile >> "CfgWeapons" >> (_x select 0)),true] call BIS_fnc_returnParents;
-			if( 'ItemCore' in _parentClasses || 'Binocular' in _parentClasses) then {
-				_toolsToBuy = _toolsToBuy + (_x select 9);
-				_toolClasses set [count _toolClasses,(_x select 0)];
-			} else {
-				_weaponsToBuy = _weaponsToBuy + (_x select 9);
-				if('PistolCore' in _parentClasses)then {
-					_sidearmToBuy = _sidearmToBuy + (_x select 9);
+_index = count (Z_BuyingArray) - 1;
+if (_index > -1) then {
+	if (Z_SingleCurrency) then {
+		{
+			if( _x select 1 == "trade_weapons")then{
+				_parentClasses =  [(configFile >> "CfgWeapons" >> (_x select 0)),true] call BIS_fnc_returnParents;
+				if( 'ItemCore' in _parentClasses || 'Binocular' in _parentClasses) then {
+					_toolsToBuy = _toolsToBuy + (_x select 9);
+					_toolClasses set [count _toolClasses,(_x select 0)];
 				} else {
-					_primaryToBuy = _primaryToBuy + (_x select 9); // _ammount
+					_weaponsToBuy = _weaponsToBuy + (_x select 9);
+					if('PistolCore' in _parentClasses)then {
+						_sidearmToBuy = _sidearmToBuy + (_x select 9);
+					} else {
+						_primaryToBuy = _primaryToBuy + (_x select 9); // _ammount
+					};
 				};
+				_priceToBuy	= _priceToBuy + ((_x select 9)*(_x select 2));
 			};
-			_priceToBuy	= _priceToBuy + ((_x select 9)*(_x select 2));
-		};
-		if( _x select 1 == "trade_items")then{
-			_magazinesToBuy = _magazinesToBuy + (_x select 9) ;
-			_priceToBuy	= _priceToBuy + ((_x select 9)*(_x select 2));
-		};
-		if( _x select 1 == "trade_backpacks")then{
-			_backpacksToBuy = _backpacksToBuy + (_x select 9) ;
-			_priceToBuy	= _priceToBuy + ((_x select 9)*(_x select 2)); // _price * _amount
-		};
-		if((_x select 1) in ["trade_any_vehicle", "trade_any_vehicle_free", "trade_any_vehicle_old", "trade_any_bicycle", "trade_any_bicycle_old", "trade_any_boat", "trade_any_boat_old"])then{
-			_vehiclesToBuy = _vehiclesToBuy + (_x select 9) ;
-			_priceToBuy	= _priceToBuy + ((_x select 9)*(_x select 2)); // _price * _amount
-		};
-		_itemsToLog set [0, (_itemsToLog select 0) + [_x select 0]];
-		_itemsToLog set [1, (_itemsToLog select 1) + [_x select 9]];
-		_itemsToLog set [2, (_itemsToLog select 2) + [((_x select 9)*(_x select 2))]];
-	} count Z_BuyingArray;
-} else {
-	{
-		if( _x select 1 == "trade_weapons")then{
-			_parentClasses =  [(configFile >> "CfgWeapons" >> (_x select 0)),true] call BIS_fnc_returnParents;
-			if( 'ItemCore' in _parentClasses || 'Binocular' in _parentClasses) then {
-				_toolsToBuy = _toolsToBuy + (_x select 9);
-				_toolClasses set [count _toolClasses,(_x select 0)];
-			} else {
-				_weaponsToBuy = _weaponsToBuy + (_x select 9);
-				if('PistolCore' in _parentClasses)then {
-					_sidearmToBuy = _sidearmToBuy + (_x select 9);
-				} else {
-					_primaryToBuy = _primaryToBuy + (_x select 9);
-				};
+			if( _x select 1 == "trade_items")then{
+				_magazinesToBuy = _magazinesToBuy + (_x select 9) ;
+				_priceToBuy	= _priceToBuy + ((_x select 9)*(_x select 2));
 			};
-			_priceToBuy	= _priceToBuy + ((_x select 11)*(_x select 2)*(_x select 9)); // _worth * _price * _amount
-		};
-		if( _x select 1 == "trade_items")then{
-			_magazinesToBuy = _magazinesToBuy + (_x select 9) ;
-			_priceToBuy	= _priceToBuy + ((_x select 11) *(_x select 2)*(_x select 9));
-		};
-		if( _x select 1 == "trade_backpacks")then{
-			_backpacksToBuy = _backpacksToBuy + (_x select 9) ;
-			_priceToBuy	= _priceToBuy + ((_x select 11)*(_x select 2)*(_x select 9));
-		};
-		if((_x select 1) in ["trade_any_vehicle", "trade_any_vehicle_free", "trade_any_vehicle_old", "trade_any_bicycle", "trade_any_bicycle_old", "trade_any_boat", "trade_any_boat_old"])then{
-			_vehiclesToBuy = _vehiclesToBuy + (_x select 9) ;
-			_priceToBuy	= _priceToBuy + ((_x select 11)*(_x select 2)*(_x select 9));
-		};
-		_itemsToLog set [0, (_itemsToLog select 0) + [_x select 0]];
-		_itemsToLog set [1, (_itemsToLog select 1) + [_x select 9]];
-		_itemsToLog set [2, (_itemsToLog select 2) + [((_x select 11)*(_x select 2)*(_x select 9))]];
-	} count Z_BuyingArray;
-};
-
-_canBuy = [_weaponsToBuy,_magazinesToBuy,_backpacksToBuy,_toolsToBuy, _sidearmToBuy, _primaryToBuy,_vehiclesToBuy,_toolClasses] call Z_allowBuying;
-
-_myMoney = player getVariable[Z_MoneyVariable,0];
-
-_enoughMoney = false;
-
-_moneyInfo = [false, [], [], [], 0];
-
-if (Z_SingleCurrency) then {
-	if (_myMoney >= _priceToBuy) then {
-		_enoughMoney = true;
+			if( _x select 1 == "trade_backpacks")then{
+				_backpacksToBuy = _backpacksToBuy + (_x select 9) ;
+				_priceToBuy	= _priceToBuy + ((_x select 9)*(_x select 2)); // _price * _amount
+			};
+			if((_x select 1) in ["trade_any_vehicle", "trade_any_vehicle_free", "trade_any_vehicle_old", "trade_any_bicycle", "trade_any_bicycle_old", "trade_any_boat", "trade_any_boat_old"])then{
+				_vehiclesToBuy = _vehiclesToBuy + (_x select 9) ;
+				_priceToBuy	= _priceToBuy + ((_x select 9)*(_x select 2)); // _price * _amount
+			};
+			_itemsToLog set [0, (_itemsToLog select 0) + [_x select 0]];
+			_itemsToLog set [1, (_itemsToLog select 1) + [_x select 9]];
+			_itemsToLog set [2, (_itemsToLog select 2) + [((_x select 9)*(_x select 2))]];
+		} count Z_BuyingArray;
 	} else {
-		_enoughMoney = false;
+		{
+			if( _x select 1 == "trade_weapons")then{
+				_parentClasses =  [(configFile >> "CfgWeapons" >> (_x select 0)),true] call BIS_fnc_returnParents;
+				if( 'ItemCore' in _parentClasses || 'Binocular' in _parentClasses) then {
+					_toolsToBuy = _toolsToBuy + (_x select 9);
+					_toolClasses set [count _toolClasses,(_x select 0)];
+				} else {
+					_weaponsToBuy = _weaponsToBuy + (_x select 9);
+					if('PistolCore' in _parentClasses)then {
+						_sidearmToBuy = _sidearmToBuy + (_x select 9);
+					} else {
+						_primaryToBuy = _primaryToBuy + (_x select 9);
+					};
+				};
+				_priceToBuy	= _priceToBuy + ((_x select 11)*(_x select 2)*(_x select 9)); // _worth * _price * _amount
+			};
+			if( _x select 1 == "trade_items")then{
+				_magazinesToBuy = _magazinesToBuy + (_x select 9) ;
+				_priceToBuy	= _priceToBuy + ((_x select 11) *(_x select 2)*(_x select 9));
+			};
+			if( _x select 1 == "trade_backpacks")then{
+				_backpacksToBuy = _backpacksToBuy + (_x select 9) ;
+				_priceToBuy	= _priceToBuy + ((_x select 11)*(_x select 2)*(_x select 9));
+			};
+			if((_x select 1) in ["trade_any_vehicle", "trade_any_vehicle_free", "trade_any_vehicle_old", "trade_any_bicycle", "trade_any_bicycle_old", "trade_any_boat", "trade_any_boat_old"])then{
+				_vehiclesToBuy = _vehiclesToBuy + (_x select 9) ;
+				_priceToBuy	= _priceToBuy + ((_x select 11)*(_x select 2)*(_x select 9));
+			};
+			_itemsToLog set [0, (_itemsToLog select 0) + [_x select 0]];
+			_itemsToLog set [1, (_itemsToLog select 1) + [_x select 9]];
+			_itemsToLog set [2, (_itemsToLog select 2) + [((_x select 11)*(_x select 2)*(_x select 9))]];
+		} count Z_BuyingArray;
 	};
-} else {
-	_moneyInfo = _priceToBuy call Z_canAfford;
-	_enoughMoney = _moneyInfo select 0;
-};
 
-if(_enoughMoney) then {
-	if(_canBuy) then {
-	_buyVehicle = {
-		private "_location";
-		_part_out = _this select 0;
-		_buyingType = _this select 1;
-		_keySelected = "0";
-		_isKeyOK= false;
-		if (_buyingType in ["trade_any_vehicle_free", "trade_any_bicycle", "trade_any_bicycle_old"]) then {
-			_isKeyOK = true;
-		} else {
-			_keyColor = ["Green","Red","Blue","Yellow","Black"] call BIS_fnc_selectRandom;
-			_keyNumber = (floor(random 2500)) + 1;
-			_keySelected = format["ItemKey%1%2",_keyColor,_keyNumber];
-			_isKeyOK = 	isClass(configFile >> "CfgWeapons" >> _keySelected);
-		};
-		if (!_isKeyOK) exitWith {localize "str_epoch_player_107" call dayz_rollingMessages; "";};
-		_activatingPlayer = player;
-		_dir = round(random 360);
-		_helipad = nearestObjects [player, ["HeliHCivil","HeliHempty"], 100];
-		
-		if(count _helipad > 0) then {
-			_location = (getPosATL (_helipad select 0));
-		} else {
-			_location = [([player] call FNC_GetPos),0,20,1,0,2000,0] call BIS_fnc_findSafePos;
-		};
+	_canBuy = [_weaponsToBuy,_magazinesToBuy,_backpacksToBuy,_toolsToBuy, _sidearmToBuy, _primaryToBuy,_vehiclesToBuy,_toolClasses] call Z_allowBuying;
 
-		_veh = createVehicle ["Sign_arrow_down_large_EP1", _location, [], 0, "CAN_COLLIDE"];
-		_location = ([_veh] call FNC_GetPos);
-		
-		if (_buyingType in ["trade_any_vehicle_free", "trade_any_bicycle", "trade_any_bicycle_old"]) then {
-			PVDZE_veh_Publish2 = [_veh,[_dir,_location],_part_out,true,"0",_activatingPlayer];
+	_myMoney = player getVariable[Z_MoneyVariable,0];
+
+	_enoughMoney = false;
+
+	_moneyInfo = [false, [], [], [], 0];
+
+	if (Z_SingleCurrency) then {
+		if (_myMoney >= _priceToBuy) then {
+			_enoughMoney = true;
 		} else {
-			PVDZE_veh_Publish2 = [_veh,[_dir,_location],_part_out,false,_keySelected,_activatingPlayer];
+			_enoughMoney = false;
 		};
-		publicVariableServer  "PVDZE_veh_Publish2";
-		_keySelected;
+	} else {
+		_moneyInfo = _priceToBuy call Z_canAfford;
+		_enoughMoney = _moneyInfo select 0;
 	};
-	systemChat localize "STR_EPOCH_PLAYER_105";
 
-	closeDialog 2;
+	if(_enoughMoney) then {
+		if(_canBuy) then {
+			_buyVehicle = {
+				private "_location";
+				_part_out = _this select 0;
+				_buyingType = _this select 1;
+				_keySelected = "0";
+				_isKeyOK= false;
+				if (_buyingType in ["trade_any_vehicle_free", "trade_any_bicycle", "trade_any_bicycle_old"]) then {
+					_isKeyOK = true;
+				} else {
+					_keyColor = ["Green","Red","Blue","Yellow","Black"] call BIS_fnc_selectRandom;
+					_keyNumber = (floor(random 2500)) + 1;
+					_keySelected = format["ItemKey%1%2",_keyColor,_keyNumber];
+					_isKeyOK = 	isClass(configFile >> "CfgWeapons" >> _keySelected);
+				};
+				if (!_isKeyOK) exitWith {localize "str_epoch_player_107" call dayz_rollingMessages; "";};
+				_activatingPlayer = player;
+				_dir = round(random 360);
+				_helipad = nearestObjects [player, ["HeliHCivil","HeliHempty"], 100];
+				
+				if(count _helipad > 0) then {
+					_location = (getPosATL (_helipad select 0));
+				} else {
+					_location = [([player] call FNC_GetPos),0,20,1,0,2000,0] call BIS_fnc_findSafePos;
+				};
 
-		if(Z_SellingFrom == 0) then { //backpack
-		_backpack = unitBackpack player;
-		systemChat format[localize "STR_EPOCH_TRADE_IN_BACKPACK",count (Z_BuyingArray)];
-			{
-				if( _x select 1 == "trade_weapons")then{
-					_backpack addWeaponCargoGlobal [_x select 0, _x select 9];
+				_veh = createVehicle ["Sign_arrow_down_large_EP1", _location, [], 0, "CAN_COLLIDE"];
+				_location = ([_veh] call FNC_GetPos);
+				
+				if (_buyingType in ["trade_any_vehicle_free", "trade_any_bicycle", "trade_any_bicycle_old"]) then {
+					PVDZE_veh_Publish2 = [_veh,[_dir,_location],_part_out,true,"0",_activatingPlayer];
+				} else {
+					PVDZE_veh_Publish2 = [_veh,[_dir,_location],_part_out,false,_keySelected,_activatingPlayer];
 				};
-				if( _x select 1 == "trade_items")then{
-					_backpack addMagazineCargoGlobal  [_x select 0, _x select 9];
-				};				
-				if((_x select 1) in ["trade_any_vehicle", "trade_any_vehicle_free", "trade_any_vehicle_old", "trade_any_bicycle", "trade_any_bicycle_old", "trade_any_boat", "trade_any_boat_old"])then{
-					_item2Add = [(_x select 0), (_x select 1)] call _buyVehicle;
-					if (_item2Add != "0") then {
-						_backpack addWeaponCargoGlobal  [_item2Add, 1];
-					};
-				};
-			} count Z_BuyingArray;
-		};
+				publicVariableServer  "PVDZE_veh_Publish2";
+				_keySelected;
+			};
+			systemChat localize "STR_EPOCH_PLAYER_105";
 
-		if(Z_SellingFrom == 1)then{ //vehicle
-			{
-				systemChat format["Adding %1 items in %2",count (Z_BuyingArray), typeOf Z_vehicle];
-				if( _x select 1 == "trade_weapons")then{
-					Z_vehicle addWeaponCargoGlobal [_x select 0, _x select 9];
-				};
-				if( _x select 1 == "trade_items")then{
-					Z_vehicle addMagazineCargoGlobal [_x select 0, _x select 9];
-				};
-				if( _x select 1 == "trade_backpacks")then{
-					Z_vehicle addBackpackCargoGlobal [_x select 0, _x select 9];
-				};
-				if((_x select 1) in ["trade_any_vehicle", "trade_any_vehicle_free", "trade_any_vehicle_old", "trade_any_bicycle", "trade_any_bicycle_old", "trade_any_boat", "trade_any_boat_old"])then{
-					_item2Add = [(_x select 0), (_x select 1)] call _buyVehicle;
-					if (_item2Add != "0") then {
-						Z_vehicle addWeaponCargoGlobal [_item2Add, 1];
-					};
-				};
-			} count Z_BuyingArray;
-		};
+			closeDialog 2;
 
-		if(Z_SellingFrom == 2)then{ //gear
-			systemChat format["Adding %1 items in gear",count (Z_BuyingArray)];
-			{
-				if( _x select 1 == "trade_weapons") then {
-					_count = 0;
-					while{ _count < (_x select 9)}do{
-						player addWeapon (_x select 0);				
-						_count = _count + 1;
+			if(Z_SellingFrom == 0) then { //backpack
+				_backpack = unitBackpack player;
+				systemChat format[localize "STR_EPOCH_TRADE_IN_BACKPACK",count (Z_BuyingArray)];
+				{
+					if( _x select 1 == "trade_weapons")then{
+						_backpack addWeaponCargoGlobal [_x select 0, _x select 9];
 					};
-				};
-				if( _x select 1 == "trade_items" ) then {
-					_count = 0;
-					 while{ _count < (_x select 9)} do {
-						player addMagazine (_x select 0);
-						_count = _count + 1;
+					if( _x select 1 == "trade_items")then{
+						_backpack addMagazineCargoGlobal  [_x select 0, _x select 9];
+					};				
+					if((_x select 1) in ["trade_any_vehicle", "trade_any_vehicle_free", "trade_any_vehicle_old", "trade_any_bicycle", "trade_any_bicycle_old", "trade_any_boat", "trade_any_boat_old"])then{
+						_item2Add = [(_x select 0), (_x select 1)] call _buyVehicle;
+						if (_item2Add != "0") then {
+							_backpack addWeaponCargoGlobal  [_item2Add, 1];
+						};
 					};
-				};
-				if( _x select 1 == "trade_backpacks")then{
+				} count Z_BuyingArray;
+			};
+
+			if(Z_SellingFrom == 1)then{ //vehicle
+				{
+					systemChat format["Adding %1 items in %2",count (Z_BuyingArray), typeOf Z_vehicle];
+					if( _x select 1 == "trade_weapons")then{
+						Z_vehicle addWeaponCargoGlobal [_x select 0, _x select 9];
+					};
+					if( _x select 1 == "trade_items")then{
+						Z_vehicle addMagazineCargoGlobal [_x select 0, _x select 9];
+					};
+					if( _x select 1 == "trade_backpacks")then{
+						Z_vehicle addBackpackCargoGlobal [_x select 0, _x select 9];
+					};
+					if((_x select 1) in ["trade_any_vehicle", "trade_any_vehicle_free", "trade_any_vehicle_old", "trade_any_bicycle", "trade_any_bicycle_old", "trade_any_boat", "trade_any_boat_old"])then{
+						_item2Add = [(_x select 0), (_x select 1)] call _buyVehicle;
+						if (_item2Add != "0") then {
+							Z_vehicle addWeaponCargoGlobal [_item2Add, 1];
+						};
+					};
+				} count Z_BuyingArray;
+			};
+
+			if(Z_SellingFrom == 2)then{ //gear
+				systemChat format["Adding %1 items in gear",count (Z_BuyingArray)];
+				{
+					if( _x select 1 == "trade_weapons") then {
+						_count = 0;
+						while{ _count < (_x select 9)}do{
+							player addWeapon (_x select 0);				
+							_count = _count + 1;
+						};
+					};
+					if( _x select 1 == "trade_items" ) then {
+						_count = 0;
+						while{ _count < (_x select 9)} do {
+							player addMagazine (_x select 0);
+							_count = _count + 1;
+						};
+					};
+					if( _x select 1 == "trade_backpacks")then{
 						player addBackpack (_x select 0);
-				};
-				if((_x select 1) in ["trade_any_vehicle", "trade_any_vehicle_free", "trade_any_vehicle_old", "trade_any_bicycle", "trade_any_bicycle_old", "trade_any_boat", "trade_any_boat_old"])then{
-					_item2Add = [(_x select 0), (_x select 1)] call _buyVehicle;
-					if (_item2Add != "0") then {
-						player addWeapon _item2Add;
 					};
-				};
-			} count Z_BuyingArray;
-		};
-		if (!Z_SingleCurrency) then {
+					if((_x select 1) in ["trade_any_vehicle", "trade_any_vehicle_free", "trade_any_vehicle_old", "trade_any_bicycle", "trade_any_bicycle_old", "trade_any_boat", "trade_any_boat_old"])then{
+						_item2Add = [(_x select 0), (_x select 1)] call _buyVehicle;
+						if (_item2Add != "0") then {
+							player addWeapon _item2Add;
+						};
+					};
+				} count Z_BuyingArray;
+			};
+			if (!Z_SingleCurrency) then {
 				_success = [player,_priceToBuy, _moneyInfo] call Z_payDefault;
 				if (_success) then {
-					systemChat format[localize "STR_EPOCH_TRADE_SUCCESS", _priceToBuy];
+					_tcost = "";
+					_tcost = _priceToBuy call z_calcDefaultCurrencyNoImg;
+					systemChat format[localize "STR_EPOCH_TRADE_BUY_SUCCESS", _tcost];
 				} else {
 					systemChat localize "STR_EPOCH_TRADE_DEBUG";
 				};
-		} else {
+			} else {
 				_success = [player,_priceToBuy] call SC_fnc_removeCoins;
 				if (_success) then {
 					systemChat format[localize "STR_EPOCH_TRADE_SUCCESS_COINS", _priceToBuy, CurrencyName];
 				} else {
 					systemChat localize "STR_EPOCH_TRADE_DEBUG";
 				};
+			};
+			_itemsToLog call Z_logTrade;
+		} else {
+			systemChat localize "STR_EPOCH_TRADE_CONTAINER_FULL";
 		};
-		_itemsToLog call Z_logTrade;
-	} else {
-		systemChat localize "STR_EPOCH_TRADE_CONTAINER_FULL";
+	}else{
+		if( Z_SingleCurrency) then {
+			systemChat format[localize "STR_EPOCH_TRADE_NEED_COINS",_priceToBuy,CurrencyName];
+		} else {
+			systemChat localize "STR_EPOCH_TRADE_NEED_MONEY";
+		};
 	};
-}else{
-	if( Z_SingleCurrency) then {
-		systemChat format[localize "STR_EPOCH_TRADE_NEED_COINS",_priceToBuy,CurrencyName];
-	} else {
-		systemChat localize "STR_EPOCH_TRADE_NEED_MONEY";
-	};
+} else {
+	systemChat localize "STR_EPOCH_TRADE_BUY_NO_ITEMS";
 };

--- a/SQF/dayz_code/actions/AdvancedTrading/functions/z_at_calcDefaultCurrencyNoImg.sqf
+++ b/SQF/dayz_code/actions/AdvancedTrading/functions/z_at_calcDefaultCurrencyNoImg.sqf
@@ -1,0 +1,118 @@
+private ["_ItemTopaz","_GemTotal","_ItemTopaz_ItemTopaz","_GemTotal2","_ItemObsidian","_ItemSapphire","_ItemAmethyst","_ItemEmerald","_ItemCitrine","_ItemRuby","_gem","_value","_string","_total","_briefcase_100oz","_gold_10oz_a","_gold_10oz_b","_gold_10oz","_gold_1oz_a","_gold_1oz_b","_gold_1oz","_silver_10oz_a","_silver_10oz_b","_silver_10oz","_silver_1oz_a","_silver_1oz_b","_silver_1oz","_dname"];
+
+_total = _this;
+_string = "";
+
+_ItemTopaz = 0;
+_ItemObsidian = 0;
+_ItemSapphire = 0;
+_ItemAmethyst = 0;
+_ItemEmerald = 0;
+_ItemCitrine = 0;
+_ItemRuby = 0;
+_GemTotal = 0;
+_GemTotal2 = _total;
+
+{
+	_gem = _x;
+	_value = DZE_GemWorthList select _forEachIndex;
+	switch(_gem) do {
+	case 'ItemTopaz': {
+			_ItemTopaz = floor(_GemTotal2 / _value);
+			if (_ItemTopaz >= 1) then {
+				_GemTotal = (_value * _ItemTopaz) + _GemTotal;
+				_GemTotal2 = _total - _GemTotal;
+			};
+		};
+	case 'ItemObsidian': {
+			_ItemObsidian = floor(_GemTotal2 / _value);
+			if (_ItemObsidian >= 1) then {
+				_GemTotal = (_value * _ItemObsidian) + _GemTotal;
+				_GemTotal2 = _total - _GemTotal;
+			};
+		};
+	case 'ItemSapphire': {
+			_ItemSapphire = floor(_GemTotal2 / _value);
+			if (_ItemSapphire >= 1) then {
+				_GemTotal = (_value * _ItemSapphire) + _GemTotal;
+				_GemTotal2 = _total - _GemTotal;
+			};
+		};
+	case 'ItemAmethyst': {
+			_ItemAmethyst = floor(_GemTotal2 / _value);
+			if (_ItemAmethyst >= 1) then {
+				_GemTotal = (_value * _ItemAmethyst) + _GemTotal;
+				_GemTotal2 = _total - _GemTotal;
+			};
+		};
+	case 'ItemEmerald': {
+			_ItemEmerald = floor(_GemTotal2 / _value);
+			if (_ItemEmerald >= 1) then {
+				_GemTotal = (_value * _ItemEmerald) + _GemTotal;
+				_GemTotal2 = _total - _GemTotal;
+			};
+		};
+	case 'ItemCitrine': {
+			_ItemCitrine = floor(_GemTotal2 / _value);
+			if (_ItemCitrine >= 1) then {
+				_GemTotal = (_value * _ItemCitrine) + _GemTotal;
+				_GemTotal2 = _total - _GemTotal;
+			};
+		};
+	case 'ItemRuby': {
+			_ItemRuby = floor(_GemTotal2 / _value);
+			if (_ItemRuby >= 1) then {
+				_GemTotal = (_value * _ItemRuby) + _GemTotal;
+				_GemTotal2 = _total - _GemTotal;
+			};
+		};
+	};
+} forEach DZE_GemList;
+
+_total = _GemTotal2;
+
+_briefcase_100oz = floor(_total / 10000);
+
+_gold_10oz_a = floor(_total / 1000);
+_gold_10oz_b = _briefcase_100oz * 10;
+_gold_10oz = (_gold_10oz_a - _gold_10oz_b);
+
+_gold_1oz_a = floor(_total / 100);
+_gold_1oz_b = _gold_10oz_a * 10;
+_gold_1oz = (_gold_1oz_a - _gold_1oz_b);
+
+_silver_10oz_a = floor(_total / 10);
+_silver_10oz_b = _gold_1oz_a * 10;
+_silver_10oz = (_silver_10oz_a - _silver_10oz_b);
+
+_silver_1oz_a = floor(_total);
+_silver_1oz_b = _silver_10oz_a * 10;
+_silver_1oz = (_silver_1oz_a - _silver_1oz_b);
+
+{ //sort gems so they display on total price in order of descending worth
+	if (!isNil {call compile format["_%1",_x]} && {(call compile format["_%1",_x]) > 0}) then {
+	_dname = getText (configFile >> 'CfgMagazines' >> _x >> 'displayName');
+	_string = format["%2 %1 %3",(call compile format["_%1",_x]), _string,_dname];
+	};
+} count DZE_GemList;
+
+if (_briefcase_100oz >= 2) then { 
+	_string = format["%2 %1 briefs",_briefcase_100oz,_string]; 
+};
+if (_briefcase_100oz == 1) then {
+	_string = format["%2 %1 brief",_briefcase_100oz,_string]; 
+};
+if (_gold_10oz > 0) then {
+	_string = format["%2 %1 10oz gold",_gold_10oz,_string];
+};
+if (_gold_1oz > 0) then {
+	_string = format["%2 %1 gold",_gold_1oz,_string];
+};
+if (_silver_10oz > 0) then {
+	_string = format["%2 %1 10oz silver",_silver_10oz,_string];
+};
+if (_silver_1oz > 0) then {
+	_string = format["%2 %1 silver",_silver_1oz, _string];
+};
+
+_string

--- a/SQF/dayz_code/actions/AdvancedTrading/functions/z_at_calcDefaultCurrencyNoImg.sqf
+++ b/SQF/dayz_code/actions/AdvancedTrading/functions/z_at_calcDefaultCurrencyNoImg.sqf
@@ -97,22 +97,22 @@ _silver_1oz = (_silver_1oz_a - _silver_1oz_b);
 } count DZE_GemList;
 
 if (_briefcase_100oz >= 2) then { 
-	_string = format["%2 %1 briefs",_briefcase_100oz,_string]; 
+	_string = format["%2 %1 %3s",_briefcase_100oz,_string,localize "STR_EPOCH_BRIEFCASE"]; 
 };
 if (_briefcase_100oz == 1) then {
-	_string = format["%2 %1 brief",_briefcase_100oz,_string]; 
+	_string = format["%2 %1 %3",_briefcase_100oz,_string,localize "STR_EPOCH_BRIEFCASE"]; 
 };
 if (_gold_10oz > 0) then {
-	_string = format["%2 %1 10oz gold",_gold_10oz,_string];
+	_string = format["%2 %1 %3",_gold_10oz,_string,localize "STR_EPOCH_10OZGOLD"];
 };
 if (_gold_1oz > 0) then {
-	_string = format["%2 %1 gold",_gold_1oz,_string];
+	_string = format["%2 %1 %3",_gold_1oz,_string,localize "STR_EPOCH_GOLD"];
 };
 if (_silver_10oz > 0) then {
-	_string = format["%2 %1 10oz silver",_silver_10oz,_string];
+	_string = format["%2 %1 %3",_silver_10oz,_string,localize "STR_EPOCH_10OZSILVER"];
 };
 if (_silver_1oz > 0) then {
-	_string = format["%2 %1 silver",_silver_1oz, _string];
+	_string = format["%2 %1 %3",_silver_1oz, _string,localize "STR_EPOCH_SILVER"];
 };
 
 _string

--- a/SQF/dayz_code/actions/AdvancedTrading/functions/z_at_displayItemInfo.sqf
+++ b/SQF/dayz_code/actions/AdvancedTrading/functions/z_at_displayItemInfo.sqf
@@ -53,8 +53,8 @@ if (Z_SingleCurrency) then {
 		"<img image='%1'  size='3' align='center'/><br />" +
 		"<t color='#33BFFF' size='0.8'>%8: </t><t color='#ffffff' size='0.8'>%2</t><br />" +
 		"<t color='#33BFFF' size='0.8'>%9: </t><t color='#ffffff' size='0.8'>%3</t><br />" +
-		"<t color='#33BFFF' size='0.8'>%10: </t><t color='#ffffff' size='0.8'>%5 %7</t><br />" +
-		"<t color='#33BFFF' size='0.8'>%11: </t><t color='#ffffff' size='0.8'>%6 %7</t><br />"
+		"<t color='#33BFFF' size='0.8'>%11: </t><t color='#ffffff' size='0.8'>%6 %7</t><br />" +
+		"<t color='#33BFFF' size='0.8'>%10: </t><t color='#ffffff' size='0.8'>%5 %7</t><br />"
 		, _picture, _display, _class, 'lazy', _sellPrice, _buyPrice, CurrencyName, localize "STR_EPOCH_NAME", localize "STR_EPOCH_CLASS", localize "STR_EPOCH_PLAYER_292", localize "STR_EPOCH_PLAYER_291"
 	];
 } else {
@@ -66,8 +66,8 @@ if (Z_SingleCurrency) then {
 		"<img image='%1'  size='3' align='center'/><br />" +
 		"<t color='#33BFFF' size='0.8'>%11: </t><t color='#ffffff' size='0.8'>%2</t><br />" +
 		"<t color='#33BFFF' size='0.8'>%12: </t><t color='#ffffff' size='0.8'>%3</t><br />" +
-		"<t color='#33BFFF' size='0.8'>%13: </t><t color='#ffffff' size='0.8'>%5 <img image='%8' /> %7</t><br />" +
-		"<t color='#33BFFF' size='0.8'>%14: </t><t color='#ffffff' size='0.8'>%6 <img image='%10' /> %9</t><br />"
+		"<t color='#33BFFF' size='0.8'>%14: </t><t color='#ffffff' size='0.8'>%6 <img image='%10' /> %9</t><br />" +
+		"<t color='#33BFFF' size='0.8'>%13: </t><t color='#ffffff' size='0.8'>%5 <img image='%8' /> %7</t><br />" 
 		, _picture, _display, _class, 'lazy', _sellPrice, _buyPrice, _sellCurrency , _picSell , _buyCurrency, _picBuy, localize "STR_EPOCH_NAME", localize "STR_EPOCH_CLASS", localize "STR_EPOCH_PLAYER_292", localize "STR_EPOCH_PLAYER_291"
 	];
 };

--- a/SQF/dayz_code/actions/AdvancedTrading/functions/z_at_displayVehicleInfo.sqf
+++ b/SQF/dayz_code/actions/AdvancedTrading/functions/z_at_displayVehicleInfo.sqf
@@ -120,8 +120,8 @@ if (Z_SingleCurrency) then {
 	"<img image='%1' size='3' /><br />" +
 	"<t color='#33BFFF' size='0.8'>%10: </t><t color='#ffffff' size='0.7'>%2</t><br />" +
 	"<t color='#33BFFF' size='0.8'>%11: </t><t color='#ffffff' size='0.7'>%3</t><br />" +
-	"<t color='#33BFFF' size='0.8'>%12: </t><t color='#ffffff' size='0.8'>%5 %7</t><br />" +
 	"<t color='#33BFFF' size='0.8'>%13: </t><t color='#ffffff' size='0.8'>%6 %7</t><br />" +
+	"<t color='#33BFFF' size='0.8'>%12: </t><t color='#ffffff' size='0.8'>%5 %7</t><br />" +
 	"<t color='#33BFFF' size='0.8'>%14/%15/%16: </t><t color='#ffffff' size='0.8'>%9/%8/%4</t><br />" +
 	"<t color='#33BFFF' size='0.8'>%17: </t><t color='#ffffff' size='0.8'>%18  </t><t color='#33BFFF' size='0.8'>%24: </t><t color='#ffffff' size='0.8'>%25</t><br />" + // Armor / Seats
 	"<t color='#33BFFF' size='0.8'>%21%22: </t><t color='#ffffff' size='0.8'>%23  </t><t color='#33BFFF' size='0.8'>%19: </t><t color='#ffffff' size='0.8'>%20</t><br />" + // MaxSpeed / Fuel
@@ -141,8 +141,8 @@ if (Z_SingleCurrency) then {
 	"<img image='%1' size='3' /><br />" +
 	"<t color='#33BFFF' size='0.8'>%13: </t><t color='#ffffff' size='0.7'>%2</t><br />" +
 	"<t color='#33BFFF' size='0.8'>%14: </t><t color='#ffffff' size='0.7'>%3</t><br />" +
-	"<t color='#33BFFF' size='0.8'>%15: </t><t color='#ffffff' size='0.8'>%5 <img image='%11' /> %10</t><br />" +
 	"<t color='#33BFFF' size='0.8'>%16: </t><t color='#ffffff' size='0.8'>%6 <img image='%12' /> %7</t><br />" +
+	"<t color='#33BFFF' size='0.8'>%15: </t><t color='#ffffff' size='0.8'>%5 <img image='%11' /> %10</t><br />" +
 	"<t color='#33BFFF' size='0.8'>%17/%18/%19: </t><t color='#ffffff' size='0.8'>%8/%9/%4</t><br />" +
 	"<t color='#33BFFF' size='0.8'>%20: </t><t color='#ffffff' size='0.8'>%21  </t><t color='#33BFFF' size='0.8'>%27: </t><t color='#ffffff' size='0.8'>%28</t><br />" + // Armor / Seats
 	"<t color='#33BFFF' size='0.8'>%24%25: </t><t color='#ffffff' size='0.8'>%26  </t><t color='#33BFFF' size='0.8'>%22: </t><t color='#ffffff' size='0.8'>%23</t><br />" + // MaxSpeed  /  Fuel

--- a/SQF/dayz_code/actions/AdvancedTrading/functions/z_at_displayWeaponInfo.sqf
+++ b/SQF/dayz_code/actions/AdvancedTrading/functions/z_at_displayWeaponInfo.sqf
@@ -66,8 +66,8 @@ if (Z_SingleCurrency) then {
 		"<img image='%1' size='3'  align='center' /><br />" +
 		"<t color='#33BFFF' size='0.8'>%8: </t><t color='#ffffff' size='0.8'>%2</t><br />" +
 		"<t color='#33BFFF' size='0.8'>%9: </t><t color='#ffffff' size='0.8'>%3</t><br />" +
-		"<t color='#33BFFF' size='0.8'>%10: </t><t color='#ffffff' size='0.8'>%5 %7</t><br />" +
-		"<t color='#33BFFF' size='0.8'>%11: </t><t color='#ffffff' size='0.8'>%6 %7</t><br />"
+		"<t color='#33BFFF' size='0.8'>%11: </t><t color='#ffffff' size='0.8'>%6 %7</t><br />" +
+		"<t color='#33BFFF' size='0.8'>%10: </t><t color='#ffffff' size='0.8'>%5 %7</t><br />"
 		, _picture, _display, _class, _magText, _sellPrice, _buyPrice, CurrencyName, localize "STR_EPOCH_NAME", localize "STR_EPOCH_CLASS", localize "STR_EPOCH_PLAYER_292", localize "STR_EPOCH_PLAYER_291"
 	];
 }else {
@@ -80,8 +80,8 @@ if (Z_SingleCurrency) then {
 		"<img image='%1' size='3'  align='center' /><br />" +
 		"<t color='#33BFFF' size='0.8'>%11: </t><t color='#ffffff' size='0.8'>%2</t><br />" +
 		"<t color='#33BFFF' size='0.8'>%12: </t><t color='#ffffff' size='0.8'>%3</t><br />" +
-		"<t color='#33BFFF' size='0.8'>%13: </t><t color='#ffffff' size='0.8'>%5 <img image='%9' /> %7</t><br />" +
-		"<t color='#33BFFF' size='0.8'>%14: </t><t color='#ffffff' size='0.8'>%6 <img image='%10' /> %8</t><br />"
+		"<t color='#33BFFF' size='0.8'>%14: </t><t color='#ffffff' size='0.8'>%6 <img image='%10' /> %8</t><br />" +
+		"<t color='#33BFFF' size='0.8'>%13: </t><t color='#ffffff' size='0.8'>%5 <img image='%9' /> %7</t><br />"
 		, _picture, _display, _class, _magText, _sellPrice, _buyPrice, _sellCurrency, _buyCurrency, _picSell, _picBuy, localize "STR_EPOCH_NAME", localize "STR_EPOCH_CLASS", localize "STR_EPOCH_PLAYER_292", localize "STR_EPOCH_PLAYER_291"
 	];
 };

--- a/SQF/dayz_code/actions/AdvancedTrading/functions/z_at_logTrade.sqf
+++ b/SQF/dayz_code/actions/AdvancedTrading/functions/z_at_logTrade.sqf
@@ -8,29 +8,44 @@ _Z_logTrade = {
 	_buyOrSell = _this select 2;
 	_price = _this select 3;
 	_container = switch (Z_SellingFrom) do {
-		case 0 : {localize "STR_EPOCH_TRADE_BACKPACK"};
-		case 1 : {localize "STR_EPOCH_TRADE_VEHICLE"};
-		case 2 : {localize "STR_UI_GEAR"};
+	case 0 : {localize "STR_EPOCH_TRADE_BACKPACK"};
+	case 1 : {localize "STR_EPOCH_TRADE_VEHICLE"};
+	case 2 : {localize "STR_UI_GEAR"};
 	};
-	_currency = if (Z_SingleCurrency) then {"Coins"} else {"Currency"};
+	_tcost = _price call Z_calcDefaultCurrencyNoImg;
+	_currency = if (Z_SingleCurrency) then {"Coins"} else {""};
 	if (isNil "inTraderCity") then {inTraderCity = "Unknown Trader City"};
 
 	// Log to client RPT
-	if (_buyOrSell == "buy") then {
-		diag_log format["%5: Bought %4 x %1 into %7 at %2 for %3x%6",_className,inTraderCity,_price,_quantity,localize "STR_EPOCH_PLAYER_289",_currency,_container];
+	if (Z_SingleCurrency) then {
+		if (_buyOrSell == "buy") then {
+			diag_log format["%5: Bought %4 x %1 into %7 at %2 for %3x%6",_className,inTraderCity,_price,_quantity,localize "STR_EPOCH_PLAYER_289",_currency,_container];
+		} else {
+			diag_log format["%5: Sold %4 x %1 from %7 at %2 for %3x%6",_className,inTraderCity,_price,_quantity,localize "STR_EPOCH_PLAYER_289",_currency,_container];
+		};
 	} else {
-		diag_log format["%5: Sold %4 x %1 from %7 at %2 for %3x%6",_className,inTraderCity,_price,_quantity,localize "STR_EPOCH_PLAYER_289",_currency,_container];
-	};
+		if (_buyOrSell == "buy") then {
+			diag_log format["%5: Bought %4 x %1 into %7 at %2 for %3",_className,inTraderCity,_tcost,_quantity,localize "STR_EPOCH_PLAYER_289",_currency,_container];
+		} else {
+			diag_log format["%5: Sold %4 x %1 from %7 at %2 for %3",_className,inTraderCity,_tcost,_quantity,localize "STR_EPOCH_PLAYER_289",_currency,_container];
+		};
+	};	
 
 	// Log to server RPT
 	if (DZE_serverLogTrades) then {
-		
-		if (_buyOrSell == "buy") then {
-			PVDZE_obj_Trade = [player,0,0,_className,inTraderCity,_currency,_price,_quantity,_container,false];
+		if (Z_SingleCurrency) then {
+			if (_buyOrSell == "buy") then {
+				PVDZE_obj_Trade = [player,0,0,_className,inTraderCity,_currency,_price,_quantity,_container,false];
+			} else {
+				PVDZE_obj_Trade = [player,0,1,_className,inTraderCity,_currency,_price,_quantity,_container,false];
+			};
 		} else {
-			PVDZE_obj_Trade = [player,0,1,_className,inTraderCity,_currency,_price,_quantity,_container,false];
+			if (_buyOrSell == "buy") then {
+				PVDZE_obj_Trade = [player,0,0,_className,inTraderCity,_currency,_tcost,_quantity,_container,false];
+			} else {
+				PVDZE_obj_Trade = [player,0,1,_className,inTraderCity,_currency,_tcost,_quantity,_container,false];
+			};
 		};
-
 		publicVariableServer "PVDZE_obj_Trade";
 	};
 };

--- a/SQF/dayz_code/actions/AdvancedTrading/functions/z_at_sellItems.sqf
+++ b/SQF/dayz_code/actions/AdvancedTrading/functions/z_at_sellItems.sqf
@@ -1,254 +1,251 @@
-private ["_index","_tempArray","_outcome","_vehCheckArray","_vehArray","_weaponsArray","_itemsArray","_bpArray","_bpCheckArray","_weaponsCheckArray","_itemsCheckArray","_VehKey","_wA","_mA","_money","_itemData","_success","_bag","_itemsToLog","_tcost"];
+private ["_tempArray","_outcome","_vehCheckArray","_vehArray","_weaponsArray","_itemsArray","_bpArray","_bpCheckArray","_weaponsCheckArray","_itemsCheckArray","_VehKey","_wA","_mA","_money","_itemData","_success","_bag","_itemsToLog","_tcost"];
 
-_index = count (Z_SellArray) - 1;
 _tempArray = Z_SellArray;
-if(_index > -1)then{
-	closeDialog 2;
-	_outcome = [];
-	_weaponsArray = [];
-	_itemsArray = [];
-	_bpArray = [];
-	_bpCheckArray = [];
-	_vehArray = [];
-	_vehCheckArray = [];
-	_weaponsCheckArray = [];
-	_itemsCheckArray = [];
-	_itemsToLog = [[],[],[],"sell"];
+closeDialog 2;
+_outcome = [];
+_weaponsArray = [];
+_itemsArray = [];
+_bpArray = [];
+_bpCheckArray = [];
+_vehArray = [];
+_vehCheckArray = [];
+_weaponsCheckArray = [];
+_itemsCheckArray = [];
+_itemsToLog = [[],[],[],"sell"];
 
-	_deleteTradedVehicle = {
-		private ["_localResult2","_VehKey2"];
-		_VehKey2 = (_this select 0) select 0;
-		_delType = _this select 1;
-		if ((count _VehKey2) > 0) then {
-			if ((_VehKey2 select 0) == "0" || _delType in ["trade_any_bicycle", "trade_any_bicycle_old", "trade_any_vehicle_free"]) then {
-				_localResult2 = 1;
-			} else {
-				{
-					if (configName(inheritsFrom(configFile >> "CfgWeapons" >> _x)) in ["ItemKeyYellow","ItemKeyBlue","ItemKeyRed","ItemKeyGreen","ItemKeyBlack"]) then {
-						if (str(getNumber(configFile >> "CfgWeapons" >> _x >> "keyid")) == (_VehKey2 select 0)) then {
-							_localResult2 = [player,_x,1] call BIS_fnc_invRemove;
-						};
-					};
-				} forEach (items player);
-			};
-			if (isNil "_localResult2") then {
-				_localResult2 = 0;
-			} else {
-				PVDZ_obj_Destroy = [(_VehKey2 select 2),(_VehKey2 select 3),player];
-				publicVariableServer "PVDZ_obj_Destroy";
-				deleteVehicle (_VehKey2 select 1);
-			};
+if (count Z_SellArray < 1) exitWith { systemChat localize "STR_EPOCH_TRADE_SELL_NO_ITEMS"; };
+
+_deleteTradedVehicle = {
+	private ["_localResult2","_VehKey2"];
+	_VehKey2 = (_this select 0) select 0;
+	_delType = _this select 1;
+	if ((count _VehKey2) > 0) then {
+		if ((_VehKey2 select 0) == "0" || _delType in ["trade_any_bicycle", "trade_any_bicycle_old", "trade_any_vehicle_free"]) then {
+			_localResult2 = 1;
 		} else {
+			{
+				if (configName(inheritsFrom(configFile >> "CfgWeapons" >> _x)) in ["ItemKeyYellow","ItemKeyBlue","ItemKeyRed","ItemKeyGreen","ItemKeyBlack"]) then {
+					if (str(getNumber(configFile >> "CfgWeapons" >> _x >> "keyid")) == (_VehKey2 select 0)) then {
+						_localResult2 = [player,_x,1] call BIS_fnc_invRemove;
+					};
+				};
+			} forEach (items player);
+		};
+		if (isNil "_localResult2") then {
 			_localResult2 = 0;
-		};
-		_localResult2;
-	};
-	_sellVehicle = {
-		private ["_distance","_damage","_tireDmg","_tires","_okToSell","_returnInfo","_textPartIn","_obj","_hitpoints","_objectID","_objectUID","_objectCharacterId","_notSetup","_part_in","_qty_in","_activatingPlayer","_objects","_qty","_vehicle"];
-		_vehicle = _this select 0;
-		_sellType = _this select 1;
-		_part_in = typeOf _vehicle;
-		_qty_in = 1;
-		_activatingPlayer = player;
-		_distance = Z_VehicleDistance;
-		_returnInfo = [];
-		_objects = nearestObjects [(getPosATL player), [_part_in], _distance];
-		_qty = ({(typeOf _x) == _part_in} count _objects);
-		if (_qty >= _qty_in) then {
-			_obj = (_objects select 0);
-			_okToSell = true;
-			_tires = 0;
-			_tireDmg = 0;
-			_damage = 0;
-			if (!(_sellType in ["trade_any_boat", "trade_any_boat_old"])) then {
-				_hitpoints = _obj call vehicle_getHitpoints;
-				{
-					if(["Wheel",_x,false] call fnc_inString) then {
-						_damage = [_obj,_x] call object_getHit;
-						_tireDmg = _tireDmg + _damage;
-						_tires = _tires + 1;
-					};
-				} forEach _hitpoints;
-				if(_tireDmg > 0 && _tires > 0) then {
-					if((_tireDmg / _tires) > 0.75) then {
-						_okToSell = false;
-					};
-				};
-			};
-			_objectID			= _obj getVariable ["ObjectID","0"];
-			_objectUID			= _obj getVariable ["ObjectUID","0"];
-			_objectCharacterId	= _obj getVariable ["CharacterID","0"];
-			_notSetup = (_objectID == "0" && _objectUID == "0");
-
-			if(local _obj && !isNull _obj && alive _obj && !_notSetup) then {
-				if(_okToSell) then {
-					_returnInfo = [_objectCharacterId, _obj, _objectID, _objectUID, _sellType];
-				} else {
-					systemChat format[localize "str_epoch_player_182",_textPartIn]; _returnInfo = [];
-				};
-			} else {
-				systemChat localize "str_epoch_player_245"; _returnInfo = [];
-			};
-		};
-		_returnInfo;
-	};
-	{
-		private ["_type","_name"];
-		_type = _x select 1;
-		_name = _x select 0;
-
-		switch (true) do {
-		case (_type == "trade_items") :
-			{
-				_itemsArray set [count(_itemsArray),_name];
-				_itemsCheckArray set [count(_itemsCheckArray),[_x select 2, _x select 11]];
-			};
-		case (_type == "trade_weapons") :
-			{
-				_weaponsArray set [count(_weaponsArray),_name];
-				_weaponsCheckArray set [count(_weaponsCheckArray),[_x select 2, _x select 11]];
-			};
-		case (_type == "trade_backpacks") :
-			{
-				_bpArray set [count(_bpArray),_name];
-				_bpCheckArray set [count(_bpCheckArray),[_x select 2, _x select 11]];
-			};
-		case (_type in ["trade_any_vehicle", "trade_any_vehicle_free", "trade_any_vehicle_old", "trade_any_bicycle", "trade_any_bicycle_old", "trade_any_boat", "trade_any_boat_old"]) :
-			{
-				if (local Z_vehicle) then {
-					_VehKey = [Z_vehicle, _type] call _sellVehicle;
-					if (count _VehKey > 0) then {
-						_vehArray set [count(_vehArray),_VehKey];
-						_vehCheckArray set [count(_vehCheckArray),[_x select 2, _x select 11]];
-					};
-				} else {
-					systemChat localize "STR_EPOCH_PLAYER_245";
-				};
-			};
-		};
-	}forEach Z_SellArray;
-
-	if(Z_SellingFrom == 0)then{
-		_outcome = [unitBackpack player,_itemsArray,_weaponsArray, _vehArray] call ZUPA_fnc_removeWeaponsAndMagazinesCargo;
-	};
-	if(Z_SellingFrom == 1)then{
-		_outcome = [Z_vehicle,_itemsArray,_weaponsArray,_bpArray, _vehArray] call ZUPA_fnc_removeWeaponsAndMagazinesCargo;
-	};
-	
-	_itemsToLog set [0,(_itemsArray + _weaponsArray + _bpArray + [typeOf Z_vehicle])];
-
-	//gear
-	if(Z_SellingFrom == 2)then{
-		private ["_localResult", "_vehTraded"];
-		_wA = [];
-		_mA = [];
-		_vehTraded = false;
-		_bagTraded = false;
-
-		{
-			if ((_x select 1) in ["trade_any_vehicle", "trade_any_vehicle_free", "trade_any_vehicle_old", "trade_any_bicycle", "trade_any_bicycle_old", "trade_any_boat", "trade_any_boat_old"]) then {
-				_localResult = [_vehArray, (_x select 1)] call _deleteTradedVehicle;
-				if (_localResult == 1) then {_vehTraded = true;};
-			} else {
-				if (_x select 1 == "trade_backpacks") then {
-					//BIS_fnc_invRemove doesn't handle backpacks
-					_bag = unitBackpack player;
-					removeBackpack player;
-					_localResult = if (_bag != (unitBackpack player)) then {1} else {0};
-					if (_localResult == 1) then {_bagTraded = true;};
-				} else {
-					_name = _x select 0;
-					_type = _x select 1;
-					if (_type == "trade_items") then {_name = configFile >> "CfgMagazines" >> _name;};
-					if (_type == "trade_weapons") then {_name = configFile >> "CfgWeapons" >> _name;};
-					_localResult = [player,_name,1] call BIS_fnc_invRemove; // Use config for BIS_fnc_invRemove
-					if(_localResult != 1)then{
-						if(_x select 1 == "trade_items")then{
-							_mA set [count(_mA),0];
-						}else{
-							_wA set [count(_wA),0];
-						};
-					}else{
-						if(_x select 1 == "trade_items")then{
-							_mA set [count(_mA),1];
-						}else{
-							_wA set [count(_wA),1];
-						};
-					};
-				};
-			};
-
-		}forEach Z_SellArray;
-
-		_outcome set [0,_mA];
-		_outcome set [1,_wA];
-		_outcome set [2,[]];
-		if (_vehTraded) then {
-			_outcome set [3,[1]];
-		};
-		if (_bagTraded) then {
-			_outcome set [2,[1]];
-		};
-	};
-	
-	{ _itemsToLog set [1, (_itemsToLog select 1) + _x] } forEach _outcome;
-	_money = 0;
-
-	if (Z_SingleCurrency) then {
-		{
-			_money = _money + ( (((_itemsCheckArray select _forEachIndex) select 0)) * _x) ;
-			_itemsToLog set [2, (_itemsToLog select 2) + [( (((_itemsCheckArray select _forEachIndex) select 0)) * _x)]];
-		}forEach (_outcome select 0);
-		{
-			_money = _money + ( (((_weaponsCheckArray select _forEachIndex) select 0)) * _x) ;
-			_itemsToLog set [2, (_itemsToLog select 2) + [( (((_weaponsCheckArray select _forEachIndex) select 0)) * _x)]];
-		}forEach (_outcome select 1);
-		{
-			_money = _money + ( ( ((_bpCheckArray select _forEachIndex) select 0) ) * _x) ;
-			_itemsToLog set [2, (_itemsToLog select 2) + [( (((_bpCheckArray select _forEachIndex) select 0)) * _x)]];
-		}forEach (_outcome select 2);
-		
-		if (count _outcome > 3) then {
-			_money = _money + ((_vehCheckArray select 0) select 0);
-			_itemsToLog set [2, (_itemsToLog select 2) + [((_vehCheckArray select 0) select 0)]];
+		} else {
+			PVDZ_obj_Destroy = [(_VehKey2 select 2),(_VehKey2 select 3),player];
+			publicVariableServer "PVDZ_obj_Destroy";
+			deleteVehicle (_VehKey2 select 1);
 		};
 	} else {
-		{
-			_itemData = _itemsCheckArray select _forEachIndex;
-			_money = _money + ( (_itemData select 0) * (_itemData select 1) * _x);
-			_itemsToLog set [2, (_itemsToLog select 2) + [( (_itemData select 0) * (_itemData select 1) * _x)]];
-		}forEach (_outcome select 0);
-		{
-			_itemData = _weaponsCheckArray select _forEachIndex;
-			_money = _money + ( (_itemData select 0) * (_itemData select 1) * _x);
-			_itemsToLog set [2, (_itemsToLog select 2) + [( (_itemData select 0) * (_itemData select 1) * _x)]];
-		}forEach (_outcome select 1);
-		{
-			_itemData = _bpCheckArray select _forEachIndex;
-			_money = _money + ( (_itemData select 0) * (_itemData select 1) * _x);
-			_itemsToLog set [2, (_itemsToLog select 2) + [( (_itemData select 0) * (_itemData select 1) * _x)]];
-		}forEach (_outcome select 2);
-		if ((count _outcome) > 3) then {
-			_itemData = _vehCheckArray select 0;
-			_money = _money + ((_itemData select 0) * (_itemData select 1));
-			_itemsToLog set [2, (_itemsToLog select 2) + [((_itemData select 0) * (_itemData select 1))]];
-		};
+		_localResult2 = 0;
 	};
-	if(typeName _money  == "SCALAR") then {
-		if (Z_SingleCurrency) then {
-			_success = [player,_money] call SC_fnc_addCoins;
-			systemChat format[localize "STR_EPOCH_TRADE_SUCCESS_CHANGE", _money , CurrencyName];
+	_localResult2;
+};
+_sellVehicle = {
+	private ["_distance","_damage","_tireDmg","_tires","_okToSell","_returnInfo","_textPartIn","_obj","_hitpoints","_objectID","_objectUID","_objectCharacterId","_notSetup","_part_in","_qty_in","_activatingPlayer","_objects","_qty","_vehicle"];
+	_vehicle = _this select 0;
+	_sellType = _this select 1;
+	_part_in = typeOf _vehicle;
+	_qty_in = 1;
+	_activatingPlayer = player;
+	_distance = Z_VehicleDistance;
+	_returnInfo = [];
+	_objects = nearestObjects [(getPosATL player), [_part_in], _distance];
+	_qty = ({(typeOf _x) == _part_in} count _objects);
+	if (_qty >= _qty_in) then {
+		_obj = (_objects select 0);
+		_okToSell = true;
+		_tires = 0;
+		_tireDmg = 0;
+		_damage = 0;
+		if (!(_sellType in ["trade_any_boat", "trade_any_boat_old"])) then {
+			_hitpoints = _obj call vehicle_getHitpoints;
+			{
+				if(["Wheel",_x,false] call fnc_inString) then {
+					_damage = [_obj,_x] call object_getHit;
+					_tireDmg = _tireDmg + _damage;
+					_tires = _tires + 1;
+				};
+			} forEach _hitpoints;
+			if(_tireDmg > 0 && _tires > 0) then {
+				if((_tireDmg / _tires) > 0.75) then {
+					_okToSell = false;
+				};
+			};
+		};
+		_objectID			= _obj getVariable ["ObjectID","0"];
+		_objectUID			= _obj getVariable ["ObjectUID","0"];
+		_objectCharacterId	= _obj getVariable ["CharacterID","0"];
+		_notSetup = (_objectID == "0" && _objectUID == "0");
+
+		if(local _obj && !isNull _obj && alive _obj && !_notSetup) then {
+			if(_okToSell) then {
+				_returnInfo = [_objectCharacterId, _obj, _objectID, _objectUID, _sellType];
+			} else {
+				systemChat format[localize "str_epoch_player_182",_textPartIn]; _returnInfo = [];
+			};
 		} else {
-			_success = [_money, 0] call Z_returnChange;
-			_tcost = "";
-			_tcost = _money call z_calcDefaultCurrencyNoImg;
-			systemChat format[localize "STR_EPOCH_TRADE_SELL_SUCCESS",_tcost];
+			systemChat localize "str_epoch_player_245"; _returnInfo = [];
 		};
-		_itemsToLog call Z_logTrade;
-	}else{
-		systemChat localize "STR_EPOCH_TRADE_DEBUG";
-		diag_log "Money is not a number. Something went wrong.";
 	};
+	_returnInfo;
+};
+{
+	private ["_type","_name"];
+	_type = _x select 1;
+	_name = _x select 0;
+
+	switch (true) do {
+	case (_type == "trade_items") :
+		{
+			_itemsArray set [count(_itemsArray),_name];
+			_itemsCheckArray set [count(_itemsCheckArray),[_x select 2, _x select 11]];
+		};
+	case (_type == "trade_weapons") :
+		{
+			_weaponsArray set [count(_weaponsArray),_name];
+			_weaponsCheckArray set [count(_weaponsCheckArray),[_x select 2, _x select 11]];
+		};
+	case (_type == "trade_backpacks") :
+		{
+			_bpArray set [count(_bpArray),_name];
+			_bpCheckArray set [count(_bpCheckArray),[_x select 2, _x select 11]];
+		};
+	case (_type in ["trade_any_vehicle", "trade_any_vehicle_free", "trade_any_vehicle_old", "trade_any_bicycle", "trade_any_bicycle_old", "trade_any_boat", "trade_any_boat_old"]) :
+		{
+			if (local Z_vehicle) then {
+				_VehKey = [Z_vehicle, _type] call _sellVehicle;
+				if (count _VehKey > 0) then {
+					_vehArray set [count(_vehArray),_VehKey];
+					_vehCheckArray set [count(_vehCheckArray),[_x select 2, _x select 11]];
+				};
+			} else {
+				systemChat localize "STR_EPOCH_PLAYER_245";
+			};
+		};
+	};
+}forEach Z_SellArray;
+
+if(Z_SellingFrom == 0)then{
+	_outcome = [unitBackpack player,_itemsArray,_weaponsArray, _vehArray] call ZUPA_fnc_removeWeaponsAndMagazinesCargo;
+};
+if(Z_SellingFrom == 1)then{
+	_outcome = [Z_vehicle,_itemsArray,_weaponsArray,_bpArray, _vehArray] call ZUPA_fnc_removeWeaponsAndMagazinesCargo;
+};
+
+_itemsToLog set [0,(_itemsArray + _weaponsArray + _bpArray + [typeOf Z_vehicle])];
+
+//gear
+if(Z_SellingFrom == 2)then{
+	private ["_localResult", "_vehTraded"];
+	_wA = [];
+	_mA = [];
+	_vehTraded = false;
+	_bagTraded = false;
+
+	{
+		if ((_x select 1) in ["trade_any_vehicle", "trade_any_vehicle_free", "trade_any_vehicle_old", "trade_any_bicycle", "trade_any_bicycle_old", "trade_any_boat", "trade_any_boat_old"]) then {
+			_localResult = [_vehArray, (_x select 1)] call _deleteTradedVehicle;
+			if (_localResult == 1) then {_vehTraded = true;};
+		} else {
+			if (_x select 1 == "trade_backpacks") then {
+				//BIS_fnc_invRemove doesn't handle backpacks
+				_bag = unitBackpack player;
+				removeBackpack player;
+				_localResult = if (_bag != (unitBackpack player)) then {1} else {0};
+				if (_localResult == 1) then {_bagTraded = true;};
+			} else {
+				_name = _x select 0;
+				_type = _x select 1;
+				if (_type == "trade_items") then {_name = configFile >> "CfgMagazines" >> _name;};
+				if (_type == "trade_weapons") then {_name = configFile >> "CfgWeapons" >> _name;};
+				_localResult = [player,_name,1] call BIS_fnc_invRemove; // Use config for BIS_fnc_invRemove
+				if(_localResult != 1)then{
+					if(_x select 1 == "trade_items")then{
+						_mA set [count(_mA),0];
+					}else{
+						_wA set [count(_wA),0];
+					};
+				}else{
+					if(_x select 1 == "trade_items")then{
+						_mA set [count(_mA),1];
+					}else{
+						_wA set [count(_wA),1];
+					};
+				};
+			};
+		};
+
+	}forEach Z_SellArray;
+
+	_outcome set [0,_mA];
+	_outcome set [1,_wA];
+	_outcome set [2,[]];
+	if (_vehTraded) then {
+		_outcome set [3,[1]];
+	};
+	if (_bagTraded) then {
+		_outcome set [2,[1]];
+	};
+};
+
+{ _itemsToLog set [1, (_itemsToLog select 1) + _x] } forEach _outcome;
+_money = 0;
+
+if (Z_SingleCurrency) then {
+	{
+		_money = _money + ( (((_itemsCheckArray select _forEachIndex) select 0)) * _x) ;
+		_itemsToLog set [2, (_itemsToLog select 2) + [( (((_itemsCheckArray select _forEachIndex) select 0)) * _x)]];
+	}forEach (_outcome select 0);
+	{
+		_money = _money + ( (((_weaponsCheckArray select _forEachIndex) select 0)) * _x) ;
+		_itemsToLog set [2, (_itemsToLog select 2) + [( (((_weaponsCheckArray select _forEachIndex) select 0)) * _x)]];
+	}forEach (_outcome select 1);
+	{
+		_money = _money + ( ( ((_bpCheckArray select _forEachIndex) select 0) ) * _x) ;
+		_itemsToLog set [2, (_itemsToLog select 2) + [( (((_bpCheckArray select _forEachIndex) select 0)) * _x)]];
+	}forEach (_outcome select 2);
+	
+	if (count _outcome > 3) then {
+		_money = _money + ((_vehCheckArray select 0) select 0);
+		_itemsToLog set [2, (_itemsToLog select 2) + [((_vehCheckArray select 0) select 0)]];
+	};
+} else {
+	{
+		_itemData = _itemsCheckArray select _forEachIndex;
+		_money = _money + ( (_itemData select 0) * (_itemData select 1) * _x);
+		_itemsToLog set [2, (_itemsToLog select 2) + [( (_itemData select 0) * (_itemData select 1) * _x)]];
+	}forEach (_outcome select 0);
+	{
+		_itemData = _weaponsCheckArray select _forEachIndex;
+		_money = _money + ( (_itemData select 0) * (_itemData select 1) * _x);
+		_itemsToLog set [2, (_itemsToLog select 2) + [( (_itemData select 0) * (_itemData select 1) * _x)]];
+	}forEach (_outcome select 1);
+	{
+		_itemData = _bpCheckArray select _forEachIndex;
+		_money = _money + ( (_itemData select 0) * (_itemData select 1) * _x);
+		_itemsToLog set [2, (_itemsToLog select 2) + [( (_itemData select 0) * (_itemData select 1) * _x)]];
+	}forEach (_outcome select 2);
+	if ((count _outcome) > 3) then {
+		_itemData = _vehCheckArray select 0;
+		_money = _money + ((_itemData select 0) * (_itemData select 1));
+		_itemsToLog set [2, (_itemsToLog select 2) + [((_itemData select 0) * (_itemData select 1))]];
+	};
+};
+if(typeName _money  == "SCALAR") then {
+	if (Z_SingleCurrency) then {
+		_success = [player,_money] call SC_fnc_addCoins;
+		systemChat format[localize "STR_EPOCH_TRADE_SUCCESS_CHANGE", _money , CurrencyName];
+	} else {
+		_success = [_money, 0] call Z_returnChange;
+		_tcost = "";
+		_tcost = _money call z_calcDefaultCurrencyNoImg;
+		systemChat format[localize "STR_EPOCH_TRADE_SELL_SUCCESS",_tcost];
+	};
+	_itemsToLog call Z_logTrade;
 }else{
-	systemChat localize "STR_EPOCH_TRADE_SELL_NO_ITEMS";
+	systemChat localize "STR_EPOCH_TRADE_DEBUG";
+	diag_log "Money is not a number. Something went wrong.";
 };

--- a/SQF/dayz_code/actions/AdvancedTrading/functions/z_at_sellItems.sqf
+++ b/SQF/dayz_code/actions/AdvancedTrading/functions/z_at_sellItems.sqf
@@ -1,4 +1,4 @@
-private ["_index","_tempArray","_outcome","_vehCheckArray","_vehArray","_weaponsArray","_itemsArray","_bpArray","_bpCheckArray","_weaponsCheckArray","_itemsCheckArray","_VehKey","_wA","_mA","_money","_itemData","_success","_bag","_itemsToLog"];
+private ["_index","_tempArray","_outcome","_vehCheckArray","_vehArray","_weaponsArray","_itemsArray","_bpArray","_bpCheckArray","_weaponsCheckArray","_itemsCheckArray","_VehKey","_wA","_mA","_money","_itemData","_success","_bag","_itemsToLog","_tcost"];
 
 _index = count (Z_SellArray) - 1;
 _tempArray = Z_SellArray;
@@ -98,22 +98,22 @@ if(_index > -1)then{
 		_name = _x select 0;
 
 		switch (true) do {
-			case (_type == "trade_items") :
+		case (_type == "trade_items") :
 			{
 				_itemsArray set [count(_itemsArray),_name];
 				_itemsCheckArray set [count(_itemsCheckArray),[_x select 2, _x select 11]];
 			};
-			case (_type == "trade_weapons") :
+		case (_type == "trade_weapons") :
 			{
 				_weaponsArray set [count(_weaponsArray),_name];
 				_weaponsCheckArray set [count(_weaponsCheckArray),[_x select 2, _x select 11]];
 			};
-			case (_type == "trade_backpacks") :
+		case (_type == "trade_backpacks") :
 			{
 				_bpArray set [count(_bpArray),_name];
 				_bpCheckArray set [count(_bpCheckArray),[_x select 2, _x select 11]];
 			};
-			case (_type in ["trade_any_vehicle", "trade_any_vehicle_free", "trade_any_vehicle_old", "trade_any_bicycle", "trade_any_bicycle_old", "trade_any_boat", "trade_any_boat_old"]) :
+		case (_type in ["trade_any_vehicle", "trade_any_vehicle_free", "trade_any_vehicle_old", "trade_any_bicycle", "trade_any_bicycle_old", "trade_any_boat", "trade_any_boat_old"]) :
 			{
 				if (local Z_vehicle) then {
 					_VehKey = [Z_vehicle, _type] call _sellVehicle;
@@ -236,18 +236,19 @@ if(_index > -1)then{
 	};
 	if(typeName _money  == "SCALAR") then {
 		if (Z_SingleCurrency) then {
-				_success = [player,_money] call SC_fnc_addCoins;
-				systemChat format[localize "STR_EPOCH_TRADE_SUCCESS_CHANGE", _money , CurrencyName];
+			_success = [player,_money] call SC_fnc_addCoins;
+			systemChat format[localize "STR_EPOCH_TRADE_SUCCESS_CHANGE", _money , CurrencyName];
 		} else {
-				_success = [_money, 0] call Z_returnChange;
-				systemChat localize "STR_EPOCH_TRADE_SUCCESSFUL";
+			_success = [_money, 0] call Z_returnChange;
+			_tcost = "";
+			_tcost = _money call z_calcDefaultCurrencyNoImg;
+			systemChat format[localize "STR_EPOCH_TRADE_SELL_SUCCESS",_tcost];
 		};
-		
 		_itemsToLog call Z_logTrade;
 	}else{
 		systemChat localize "STR_EPOCH_TRADE_DEBUG";
 		diag_log "Money is not a number. Something went wrong.";
 	};
 }else{
-	systemChat localize "STR_EPOCH_TRADE_NO_ITEMS";
+	systemChat localize "STR_EPOCH_TRADE_SELL_NO_ITEMS";
 };

--- a/SQF/dayz_code/actions/AdvancedTrading/init.sqf
+++ b/SQF/dayz_code/actions/AdvancedTrading/init.sqf
@@ -95,10 +95,11 @@ if(isNil "Z_AdvancedTradingInit")then{
 	Z_calculateFreeSpace = 						compile preprocessFileLineNumbers (Z_AT_FolderLocation + "\functions\z_at_calculateFreeSpace.sqf");
 	Z_checkCloseVehicle =  						compile preprocessFileLineNumbers (Z_AT_FolderLocation + "\functions\z_at_checkCloseVehicle.sqf");
 	Z_allowBuying =  							compile preprocessFileLineNumbers (Z_AT_FolderLocation + "\functions\z_at_allowBuying.sqf");
-	Z_canAfford =  							compile preprocessFileLineNumbers (Z_AT_FolderLocation + "\functions\z_at_canAfford.sqf");
+	Z_canAfford =  								compile preprocessFileLineNumbers (Z_AT_FolderLocation + "\functions\z_at_canAfford.sqf");
 	Z_returnChange =  							compile preprocessFileLineNumbers (Z_AT_FolderLocation + "\functions\z_at_returnChange.sqf");
 	Z_payDefault =  							compile preprocessFileLineNumbers (Z_AT_FolderLocation + "\functions\z_at_payDefault.sqf");
-	Z_calcDefaultCurrency =			compile preprocessFileLineNumbers (Z_AT_FolderLocation + "\functions\z_at_calcDefaultCurrency.sqf");
+	Z_calcDefaultCurrency =						compile preprocessFileLineNumbers (Z_AT_FolderLocation + "\functions\z_at_calcDefaultCurrency.sqf");
+	z_calcDefaultCurrencyNoImg  =				compile preprocessFileLineNumbers (Z_AT_FolderLocation + "\functions\z_at_calcDefaultCurrencyNoImg.sqf");
 
 	Z_AdvancedTradingInit = true;
 };

--- a/SQF/dayz_code/stringtable.xml
+++ b/SQF/dayz_code/stringtable.xml
@@ -15765,11 +15765,9 @@
 		</Key>
 		<Key ID="STR_EPOCH_TRADE_BUY_NO_ITEMS">
 			<English>No items in buy list</English>
-			<Russian>???? ???? ???? ????</Russian>
 		</Key>
 		<Key ID="STR_EPOCH_TRADE_SELL_NO_ITEMS">
-			<English>No items sell list</English>
-			<Russian>???? ???? ???? ????</Russian>
+			<English>No items in sell list</English>
 		</Key>
 		<Key ID="STR_EPOCH_TRADE_DETAILS">
 			<English>Details</English>
@@ -15880,7 +15878,7 @@
 		</Key>
 		<Key ID="STR_EPOCH_TRADE_SELL_SUCCESS">
 			<English>Trade successfull, received:%1.</English>
-			<Russian>???? ???? ???? ????</Russian>
+			<Russian>Продажа завершена. Получено:%1</Russian>
 		</Key>
 		<Key ID="STR_EPOCH_TRADE_SUCCESS_COINS">
 			<English>Trade successfull, paid %1 %2.</English>

--- a/SQF/dayz_code/stringtable.xml
+++ b/SQF/dayz_code/stringtable.xml
@@ -15763,9 +15763,13 @@
 			<English>No info found</English>
 			<Russian>Нет информации</Russian>
 		</Key>
-		<Key ID="STR_EPOCH_TRADE_NO_ITEMS">
-			<English>No items to sell</English>
-			<Russian>Нет ничего на продажу</Russian>
+		<Key ID="STR_EPOCH_TRADE_BUY_NO_ITEMS">
+			<English>No items in buy list</English>
+			<Russian>???? ???? ???? ????</Russian>
+		</Key>
+		<Key ID="STR_EPOCH_TRADE_SELL_NO_ITEMS">
+			<English>No items sell list</English>
+			<Russian>???? ???? ???? ????</Russian>
 		</Key>
 		<Key ID="STR_EPOCH_TRADE_DETAILS">
 			<English>Details</English>
@@ -15870,12 +15874,16 @@
 			<English>Trade successfull.</English>
 			<Russian>Продажа завершена.</Russian>
 		</Key>
-		<Key ID="STR_EPOCH_TRADE_SUCCESS">
-			<English>Trade successfull, payed %1 worth of items.</English>
+		<Key ID="STR_EPOCH_TRADE_BUY_SUCCESS">
+			<English>Trade successfull, paid:%1.</English>
 			<Russian>Продано! С вас %1.</Russian>
 		</Key>
+		<Key ID="STR_EPOCH_TRADE_SELL_SUCCESS">
+			<English>Trade successfull, received:%1.</English>
+			<Russian>???? ???? ???? ????</Russian>
+		</Key>
 		<Key ID="STR_EPOCH_TRADE_SUCCESS_COINS">
-			<English>Trade successfull, payed %1 %2.</English>
+			<English>Trade successfull, paid %1 %2.</English>
 			<Russian>Продано! С вас %1 %2.</Russian>
 		</Key>
 		<Key ID="STR_EPOCH_TRADE_SUCCESS_CHANGE">

--- a/SQF/dayz_server/compile/server_tradeObject.sqf
+++ b/SQF/dayz_server/compile/server_tradeObject.sqf
@@ -19,7 +19,8 @@ if (count _this > 7) then {
 };
 
 _clientID = 	owner _player;
-_price = format ["%1x%2",_price,_currency];
+
+if (typeName _price  == "SCALAR") then { _price = format ["%1x%2",_price,_currency]; } else { _price = format ["%1",_price]; };
 _name = if (alive _player) then { name _player; } else { "Dead Player"; };
 _PUID = [_player] call FNC_GetPlayerUID;
 

--- a/SQF/dayz_server/compile/server_tradeObject.sqf
+++ b/SQF/dayz_server/compile/server_tradeObject.sqf
@@ -25,9 +25,9 @@ _name = if (alive _player) then { name _player; } else { "Dead Player"; };
 _PUID = [_player] call FNC_GetPlayerUID;
 
 if (_buyorsell == 0) then { //Buy
-diag_log format["%8: %9: %1 (%2) bought %6 x %3 into %7 at %4 for %5", _name, _PUID, _classname, _traderCity, _price, _quantity,_container,localize "STR_EPOCH_PLAYER_289",localize "STR_EPOCH_PLAYER"];
+	diag_log format["%8: %9: %1 (%2) bought %6 x %3 into %7 at %4 for %5", _name, _PUID, _classname, _traderCity, _price, _quantity,_container,localize "STR_EPOCH_PLAYER_289",localize "STR_EPOCH_PLAYER"];
 } else { //SELL
-diag_log format["%8: %9: %1 (%2) sold %6 x %3 from %7 at %4 for %5",_name, _PUID, _classname, _traderCity, _price, _quantity,_container,localize "STR_EPOCH_PLAYER_289",localize "STR_EPOCH_PLAYER"];
+	diag_log format["%8: %9: %1 (%2) sold %6 x %3 from %7 at %4 for %5",_name, _PUID, _classname, _traderCity, _price, _quantity,_container,localize "STR_EPOCH_PLAYER_289",localize "STR_EPOCH_PLAYER"];
 };
 
 if (DZE_ConfigTrader) then {


### PR DESCRIPTION
This adds combine currency option to the Advanced trading screen since @Airwaves man noticed it didn't have a way of doing it.

Updated stringtables with correct "paid" spelling and differing text for buying/selling.

This also addds proper currency checking/reporting for the log system that has been introduced, it's untidy but it works, instead of getting "user bought x for 1000 currency" in a non coins server, it will convert it to the proper 1 brief 5 10oz gold etc system (uses a new function z_calcDefaultCurrencyNoImg)

This also adds a check to see if the buy list is empty (as per the selling list) and returns text to the user informing them.

Re-arranged buy and sell so buy is on top of sell, it's a bit easier to read then.

This changes the server_tradeobject to check if it's being passed a number (single currency) or text (my logging currency changes)