### PR TITLE
Various changes (snappoints, dooraccess and fn_selfactions)

### DIFF
--- a/SQF/dayz_code/Configs/CfgExtra/snappoints.hpp
+++ b/SQF/dayz_code/Configs/CfgExtra/snappoints.hpp
@@ -242,8 +242,8 @@ class SnapBuilding {
 	class Cinder_DZE: FloorsWallsStairs { //All cinder walls and doors
 		points[] = {
 		{0,0,0,"Pivot"},
-		{-2.752, 0, 1.5,"Left"},
-		{2.752, 0, 1.5,"Right"},
+		{-2.64, 0, 1.5,"Left"},
+		{2.64, 0, 1.5,"Right"},
 		{0, 0, 3.37042,"Top"}
 		};
 		radius = 10;
@@ -254,8 +254,8 @@ class SnapBuilding {
 	class CinderWallHalf_Preview_DZ: Cinder_DZE {
 		points[] = {
 		{0,0,0,"Pivot"},
-		{-2.752, 0, 1.5,"Left"},
-		{2.752, 0, 1.5,"Right"},
+		{-2.64, 0, 1.5,"Left"},
+		{2.64, 0, 1.5,"Right"},
 		{0, 0, 1.5,"Top"}
 		};
 	};
@@ -268,8 +268,8 @@ class SnapBuilding {
 	class CinderWallHalf_DZ: Cinder_DZE {
 		points[] = {
 		{0,0,0,"Pivot"},
-		{-2.752, 0, 1.5,"Left"},
-		{2.752, 0, 1.5,"Right"},
+		{-2.64, 0, 1.5,"Left"},
+		{2.64, 0, 1.5,"Right"},
 		{0, 0, 1.5,"Top"}
 		};
 	};

--- a/SQF/dayz_code/Configs/RscDisplay/doorManagement/doorAccess.hpp
+++ b/SQF/dayz_code/Configs/RscDisplay/doorManagement/doorAccess.hpp
@@ -4,7 +4,7 @@ class DoorAccess
 	movingenable = 0;
 	
 	onLoad = "keypadCancel = true;";
-	onUnload = "if(keypadCancel) then {DZE_Lock_Door = ''; [] spawn keyPadReset;} else {DZE_Lock_Door = dayz_playerUID;};";
+	onUnload = "if(keypadCancel) then {DZE_Lock_Door = ''; [] spawn keyPadReset;};";
 	
 	class Controls
 	{

--- a/SQF/dayz_code/compile/fn_selfActions.sqf
+++ b/SQF/dayz_code/compile/fn_selfActions.sqf
@@ -248,7 +248,7 @@ if (!isNull _cursorTarget && !_inVehicle && !_isPZombie && (player distance _cur
 	_upgradeItems = ["TentStorage","TentStorage0","TentStorage1","TentStorage2","TentStorage3","StashSmall","StashSmall1","StashSmall2","StashSmall3","StashSmall4","StashMedium","StashMedium1","StashMedium2","StashMedium3","DomeTentStorage","DomeTentStorage0","DomeTentStorage1","DomeTentStorage2","DomeTentStorage3","DomeTentStorage4"];
 	_isCampSite = _cursorTarget isKindOf "IC_Fireplace1";	
 	_characterID = _cursorTarget getVariable ["CharacterID","0"];
-	_upgrade = getArray (configFile >> "CfgVehicles" >> (typeOf _cursorTarget) >> "upgradeBuilding");	
+	_upgrade = getArray (configFile >> "CfgVehicles" >> (typeOf _cursorTarget) >> "upgradeBuilding");
 	
 	if (DZE_permanentPlot) then {
 		_id = [player] call FNC_GetPlayerUID;

--- a/SQF/dayz_code/compile/fn_selfActions.sqf
+++ b/SQF/dayz_code/compile/fn_selfActions.sqf
@@ -5,7 +5,7 @@ scriptName "Functions\misc\fn_selfActions.sqf";
 	- [] call fnc_usec_selfActions;
 ************************************************************/
 if (DZE_ActionInProgress) exitWith {};
-private ["_canPickLight","_text","_dir","_canDoThis","_w2m","_bb","_waterHoles","_unlock","_lock","_totalKeys","_temp_keys","_temp_keys_names","_hasKey","_oldOwner","_hasAttached","_isAnimal","_isZombie","_isHarvested","_isMan","_isFuel","_hasRawMeat","_hastinitem","_player_deleteBuild","_player_lockUnlock_crtl","_displayName","_hasIgnators","_menu","_menu1","_allowTow","_liftHeli","_found","_posL","_posC","_height","_attached","_combi","_findNearestGen","_humanity_logic","_low_high","_cancel","_buy","_buyV","_humanity","_traderMenu","_warn","_typeOfCursorTarget","_isVehicle","_isBicycle","_isDestructable","_isGenerator","_ownerID","_isVehicletype","_hasBarrel","_hasFuel20","_hasFuel5","_hasEmptyFuelCan","_itemsPlayer","_hasToolbox","_hasbottleitem","_isAlive","_isPlant","_istypeTent","_upgradeItems","_isCampSite","_isDisallowRefuel","_isDog","_isModular","_isModularDoor","_isHouse","_isGate","_isFence","_isLockableGate","_isUnlocked","_isOpen","_isClosed","_ownerArray","_ownerBuildLock","_ownerPID","_speed","_dog","_vehicle","_inVehicle","_cursorTarget","_primaryWeapon","_currentWeapon","_magazinesPlayer","_onLadder","_canDo","_nearLight","_vehicleOwnerID","_hasHotwireKit","_isPZombie","_dogHandle","_allowedDistance","_id"];
+private ["_canPickLight","_text","_dir","_canDoThis","_w2m","_bb","_waterHoles","_unlock","_lock","_totalKeys","_temp_keys","_temp_keys_names","_hasKey","_oldOwner","_hasAttached","_isAnimal","_isZombie","_isHarvested","_isMan","_isFuel","_hasRawMeat","_hastinitem","_player_deleteBuild","_player_lockUnlock_crtl","_displayName","_hasIgnators","_menu","_menu1","_allowTow","_liftHeli","_found","_posL","_posC","_height","_attached","_combi","_findNearestGen","_humanity_logic","_low_high","_cancel","_buy","_buyV","_humanity","_traderMenu","_warn","_typeOfCursorTarget","_isVehicle","_isBicycle","_isDestructable","_isGenerator","_ownerID","_isVehicletype","_hasBarrel","_hasFuel20","_hasFuel5","_hasEmptyFuelCan","_itemsPlayer","_hasToolbox","_hasbottleitem","_isAlive","_isPlant","_istypeTent","_upgradeItems","_isCampSite","_isDisallowRefuel","_isDog","_isModular","_isModularDoor","_isHouse","_isGate","_isFence","_isLockableGate","_isUnlocked","_isOpen","_isClosed","_ownerArray","_ownerBuildLock","_ownerPID","_speed","_dog","_vehicle","_inVehicle","_cursorTarget","_primaryWeapon","_currentWeapon","_magazinesPlayer","_onLadder","_canDo","_nearLight","_vehicleOwnerID","_hasHotwireKit","_isPZombie","_dogHandle","_allowedDistance","_id","_upgrade"];
 
 _vehicle = vehicle player;
 _inVehicle = (_vehicle != player);
@@ -248,6 +248,7 @@ if (!isNull _cursorTarget && !_inVehicle && !_isPZombie && (player distance _cur
 	_upgradeItems = ["TentStorage","TentStorage0","TentStorage1","TentStorage2","TentStorage3","StashSmall","StashSmall1","StashSmall2","StashSmall3","StashSmall4","StashMedium","StashMedium1","StashMedium2","StashMedium3","DomeTentStorage","DomeTentStorage0","DomeTentStorage1","DomeTentStorage2","DomeTentStorage3","DomeTentStorage4"];
 	_isCampSite = _cursorTarget isKindOf "IC_Fireplace1";	
 	_characterID = _cursorTarget getVariable ["CharacterID","0"];
+	_upgrade = getArray (configFile >> "CfgVehicles" >> (typeOf _cursorTarget) >> "upgradeBuilding");	
 	
 	if (DZE_permanentPlot) then {
 		_id = [player] call FNC_GetPlayerUID;
@@ -422,7 +423,7 @@ if (!isNull _cursorTarget && !_inVehicle && !_isPZombie && (player distance _cur
 		if(_isModular || _isModularDoor || {_typeOfCursorTarget in DZE_isDestroyableStorage}) then {
 			if(_hasToolbox && "ItemCrowbar" in _itemsPlayer) then {
 				_isowner = [player, _cursorTarget] call FNC_check_access;
-				if ((_isowner select 0) or (_isowner select 1) or (_isowner select 2)) then {
+				if ((_isowner select 0) or (_isowner select 2) or (_isowner select 3)) then {
 					_player_deleteBuild = true;
 				};
 			};
@@ -635,7 +636,7 @@ if (!isNull _cursorTarget && !_inVehicle && !_isPZombie && (player distance _cur
 		if (DZE_permanentPlot) then {
 			if (s_player_plotManagement < 0) then {
 				_isowner = [player, _cursorTarget] call FNC_check_access;
-				if ((_isowner select 0) or (_isowner select 3) or (_isowner select 4)) then {
+				if ((_isowner select 0) or (_isowner select 2) or (_isowner select 3) or (_isowner select 4)) then {
 					s_player_plotManagement = player addAction [format["<t color='#0059FF'>%1</t>",localize "STR_EPOCH_ACTIONS_MANAGEPLOT"], "\z\addons\dayz_code\actions\plotManagement\initPlotManagement.sqf", [], 5, false];
 				};
 			};
@@ -885,8 +886,11 @@ if (!isNull _cursorTarget && !_inVehicle && !_isPZombie && (player distance _cur
 			};
 		};
 		if (s_player_upgrade_build < 0) then {
-			s_player_lastTarget set [0,_cursorTarget];
-			s_player_upgrade_build = player addAction [format[localize "str_upgrade",_text], "\z\addons\dayz_code\actions\player_upgrade.sqf",_cursorTarget, -1, false, true];
+			_isowner = [player, _cursorTarget] call FNC_check_access;
+			if (((_isowner select 0) or (_isowner select 2) or (_isowner select 3)) && (count _upgrade) > 0) then {
+				s_player_lastTarget set [0,_cursorTarget];
+				s_player_upgrade_build = player addAction [format[localize "str_upgrade",_text], "\z\addons\dayz_code\actions\player_upgrade.sqf",_cursorTarget, -1, false, true];
+			};
 		};
 	} else {
 		player removeAction s_player_upgrade_build;
@@ -902,8 +906,11 @@ if (!isNull _cursorTarget && !_inVehicle && !_isPZombie && (player distance _cur
 			};
 		};
 		if (s_player_downgrade_build < 0) then {
-			s_player_lastTarget set [1,_cursorTarget];
-			s_player_downgrade_build = player addAction [format[localize "STR_EPOCH_ACTIONS_REMLOCK",_text], "\z\addons\dayz_code\actions\player_buildingDowngrade.sqf",_cursorTarget, -2, false, true];
+			_isowner = [player, _cursorTarget] call FNC_check_access;
+			if ((_isowner select 0) or (_isowner select 2) or (_isowner select 3)) then {
+				s_player_lastTarget set [1,_cursorTarget];
+				s_player_downgrade_build = player addAction [format[localize "STR_EPOCH_ACTIONS_REMLOCK",_text], "\z\addons\dayz_code\actions\player_buildingDowngrade.sqf",_cursorTarget, -2, false, true];
+			};
 		};
 	} else {
 		player removeAction s_player_downgrade_build;
@@ -919,9 +926,12 @@ if (!isNull _cursorTarget && !_inVehicle && !_isPZombie && (player distance _cur
 			};
 		};
 		if (s_player_maint_build < 0) then {
-			_text2 = _text + " (" + str(round ((damage _cursorTarget) * 100)) + "% damaged)";
-			s_player_lastTarget set [2,_cursorTarget];
-			s_player_maint_build = player addAction [format["%1 %2",localize "STR_EPOCH_ACTIONS_MAINTAIN",_text2], "\z\addons\dayz_code\actions\player_buildingMaint.sqf",_cursorTarget, -2, false, true];
+			_isowner = [player, _cursorTarget] call FNC_check_access;
+			if ((_isowner select 0) or (_isowner select 2) or (_isowner select 3)) then {
+				_text2 = _text + " (" + str(round ((damage _cursorTarget) * 100)) + "% damaged)";
+				s_player_lastTarget set [2,_cursorTarget];
+				s_player_maint_build = player addAction [format["%1 %2",localize "STR_EPOCH_ACTIONS_MAINTAIN",_text2], "\z\addons\dayz_code\actions\player_buildingMaint.sqf",_cursorTarget, -2, false, true];
+			};
 		};
 	} else {
 		player removeAction s_player_maint_build;


### PR DESCRIPTION
Changes to snappoints.hpp fixes issues with metal floors snapping to a cinder wall. Cinder to cinder will create small gaps and then metal floors won't properly line up unless you start with a metal floor then snap cinders. By making both the same snap size, this fixes this issue.

Changes to doorAccess.hpp makes it possible to unlock doors and downgrade them again. It was setting dze_lock_door to the players UID instead of the door code as it should so the conditions would not be met in fn_selfActions to give you additional access.

Changes to fn_selfActions refine access to certain points more accurately (the way they should be IMO)

1) Adds a check to see if the building item can be upgraded anymore before presenting the menu, this stops you receiving the "upgrade item" action even when the item is fully upgraded
2) Adds access checks to the maintain individual item menu action so only item owner, plot owner and plot friends will see it, same with the above upgrade item menu action, this will also stop you receiving this when you are on someone elses plot that you may not have access to (I.e it's useless)
3) Changes modular building access to be item owner, plot owner and plot friend to remove modular items.
4) Changes plot managment action menu so item owner, plot owner and plot friend can access it. I thought there could be a situation where item owner != plot owner. This can be reverted if that is never possible.
5) Changes downgrading so only item owner, plot owner and plot friends can access it. If someone has the door code that doesn't mean they should be able to remove the combo (IMO)