### PR TITLE
Plot for life fixes and typo fixes

### DIFF
--- a/SQF/dayz_code/Configs/CfgWeapons/Rifles/MR43.hpp
+++ b/SQF/dayz_code/Configs/CfgWeapons/Rifles/MR43.hpp
@@ -9,7 +9,7 @@ class MR43_DZ : Rifle
 	
 	magazines[] =
 	{
-		2Rnd_12Gauge_Buck;		
+		2Rnd_12Gauge_Buck,
 		2Rnd_12Gauge_Slug		
 	};
 	

--- a/SQF/dayz_code/actions/player_build.sqf
+++ b/SQF/dayz_code/actions/player_build.sqf
@@ -433,10 +433,11 @@ if (_canBuild select 0) then {
 					};
 
 					_tmpbuilt setVariable ["CharacterID",_combination,true];
-					PVDZ_obj_Publish = [_combination,_tmpbuilt,[_dir,_location],[]];
 					if (DZE_permanentPlot) then {
 						_tmpbuilt setVariable ["ownerPUID",_playerUID,true];
 						PVDZ_obj_Publish = [_combination,_tmpbuilt,[_dir,_location,_playerUID],_classname];
+					} else {
+						PVDZ_obj_Publish = [_combination,_tmpbuilt,[_dir,_location],[]];
 					};
 					publicVariableServer "PVDZ_obj_Publish";
 
@@ -452,9 +453,10 @@ if (_canBuild select 0) then {
 					if(_tmpbuilt isKindOf "Land_Fire_DZ") then {
 						_tmpbuilt spawn player_fireMonitor;
 					} else {
-						PVDZ_obj_Publish = [dayz_characterID,_tmpbuilt,[_dir,_location],[]];
 						if (DZE_permanentPlot) then {
 							PVDZ_obj_Publish = [dayz_characterID,_tmpbuilt,[_dir,_location,_playerUID],_classname];
+						} else {
+							PVDZ_obj_Publish = [dayz_characterID,_tmpbuilt,[_dir,_location],[]];
 						};
 						publicVariableServer "PVDZ_obj_Publish";
 					};

--- a/SQF/dayz_code/actions/player_buildingDowngrade.sqf
+++ b/SQF/dayz_code/actions/player_buildingDowngrade.sqf
@@ -103,12 +103,14 @@ if ((count _upgrade) > 0) then {
 		// Set location
 		_object setPosATL _location;
 
-
 		format[localize "str_epoch_player_142",_text] call dayz_rollingMessages;
 
-		PVDZE_obj_Swap = [_objectCharacterID,_object,[_dir,_location, _vector],_classname,_obj,player];
 		if (DZE_permanentPlot) then {
+			_ownerID = _obj getVariable["ownerPUID","0"];
+			_object setVariable ["ownerPUID",_ownerID,true];
 			PVDZE_obj_Swap = [_objectCharacterID,_object,[_dir,_location,_playerUID, _vector],_classname,_obj,player];
+		} else {
+			PVDZE_obj_Swap = [_objectCharacterID,_object,[_dir,_location, _vector],_classname,_obj,player];
 		};
 		publicVariableServer "PVDZE_obj_Swap";
 

--- a/SQF/dayz_code/actions/player_upgrade.sqf
+++ b/SQF/dayz_code/actions/player_upgrade.sqf
@@ -110,10 +110,6 @@ if ((count _upgrade) > 0) then {
 
 			// Set location
 			_object setPosATL _location;
-			if (DZE_permanentPlot) then {
-				_ownerID = _obj getVariable["ownerPUID","0"];
-				_object setVariable ["ownerPUID",_ownerID,true];
-			};
 
 			if (_lockable == 3) then {
 
@@ -128,8 +124,14 @@ if ((count _upgrade) > 0) then {
 			} else {	
 				format[localize "str_epoch_player_159",_text] call dayz_rollingMessages;
 			};
-
-			PVDZE_obj_Swap = [_objectCharacterID,_object,[_dir,_location, _vector],_classname,_obj,player];
+			if (DZE_permanentPlot) then {
+				_ownerID = _obj getVariable["ownerPUID","0"];
+				if (_ownerID == "0") then { _ownerID = [player] call FNC_GetPlayerUID; }; //APFL is on but UID is 0 so we will claim it to record the ownership.
+				_object setVariable ["ownerPUID",_ownerID,true];
+				PVDZE_obj_Swap = [_objectCharacterID,_object,[_dir,_location,_ownerID,_vector],_classname,_obj,player];
+			} else {
+				PVDZE_obj_Swap = [_objectCharacterID,_object,[_dir,_location,_vector],_classname,_obj,player];
+			};
 			publicVariableServer "PVDZE_obj_Swap";
 
 			player reveal _object;

--- a/SQF/dayz_code/credits.txt
+++ b/SQF/dayz_code/credits.txt
@@ -75,7 +75,7 @@ feature.
  * [Nick Chow] (https://github.com/Purplish)
  * bittedanke (https://github.com/bittedanke) - fixing a problem with chances.
  * ebaydayz (https://github.com/ebaydayz)
- * xyberviri (https://github.com/xyberviri) - ((action_open_backpack_0.ogg - action_open_backpack_4.ogg), (action_open_inventory_0.ogg - action_open_inventory_4.ogg)) Licesne Info - https://github.com/DayZMod/DayZ/issues/696
+ * xyberviri (https://github.com/xyberviri) - ((action_open_backpack_0.ogg - action_open_backpack_4.ogg), (action_open_inventory_0.ogg - action_open_inventory_4.ogg)) License Info - https://github.com/DayZMod/DayZ/issues/696
  
 ------------------------
 Art Work


### PR DESCRIPTION
This fixes the issues I was having with APFL, Basically when downgrading
a locked door the ownerPUID was not getting transferred across so it was
getting a 0 PUID set on it once downgraded so you would then lose access
if there was no plot pole.

Now it correctly gets set and instead of doing 2 PVDZE_Obj_Swaps I am
using an if and else statement.

player_upgrade was also not sending the ownerID into the worldspace
field, this seems to differ from the original APFL script. I also added
in code so that if APFL was enabled and uid is 0 we claim the item with
players UID.

This fixes a typo @ebaydayz introduced to spam the .RPT on startup also
for the shotgun and a typo in the credits.