### PR TITLE
Snap point changes

### DIFF
--- a/SQF/dayz_code/Configs/CfgExtra/snappoints.hpp
+++ b/SQF/dayz_code/Configs/CfgExtra/snappoints.hpp
@@ -242,29 +242,38 @@ class SnapBuilding {
 	class Cinder_DZE: FloorsWallsStairs { //All cinder walls and doors
 		points[] = {
 		{0,0,0,"Pivot"},
-		{-2.64, 0, 1.5,"Left"},
-		{2.64, 0, 1.5,"Right"},
+		{-2.64, 0, 1.685,"Left"},
+		{2.64, 0, 1.685,"Right"},
 		{0, 0, 3.37042,"Top"}
 		};
 		radius = 10;
 	};
-	class CinderWall_Preview_DZ: Cinder_DZE {};
+	class CinderWall_Preview_DZ: Cinder_DZE {
+		points[] = {
+		{0,0,0,"Pivot"},
+		{-2.64, 0, 0,"Left"},
+		{2.64, 0, 0,"Right"},
+		{0, 0, 1.685,"Top"},
+		{0,0,-1.685,"Bottom"}
+		};
+	};
 	class CinderWallDoorway_Preview_DZ: Cinder_DZE {};
 	class CinderWallSmallDoorway_Preview_DZ: Cinder_DZE {}; 
 	class CinderWallHalf_Preview_DZ: Cinder_DZE {
 		points[] = {
 		{0,0,0,"Pivot"},
-		{-2.64, 0, 1.5,"Left"},
-		{2.64, 0, 1.5,"Right"},
+		{-2.64, 0, 1.685,"Left"},
+		{2.64, 0, 1.685,"Right"},
 		{0, 0, 1.5,"Top"}
 		};
 	};
 	class CinderWall_DZ: Cinder_DZE {
 		points[] = {
 		{0,0,0,"Pivot"},
-		{-2.84, 0, 3.2,"Left"},
-		{2.84, 0, 3.2,"Right"},
-		{0, 0, 3.2,"Top"}
+		{-2.64, 0, 1.685,"Left"},
+		{2.64, 0, 1.685,"Right"},
+		{0, 0, 3.37042,"Top"},
+		{0,0,-1.685,"Bottom"}
 		};
 	};
 	class CinderWallDoorway_DZ: Cinder_DZE {};
@@ -275,34 +284,33 @@ class SnapBuilding {
 	class CinderWallHalf_DZ: Cinder_DZE {
 		points[] = {
 		{0,0,0,"Pivot"},
-		{-2.64, 0, 1.5,"Left"},
-		{2.64, 0, 1.5,"Right"},
-		{0, 0, 1.5,"Top"}
+		{-2.64, 0, 1.685,"Left"},
+		{2.64, 0, 1.685,"Right"},
+		{0, 0, 1.685,"Top"}
 		};
 	};
 	class CinderWallDoorSmall_DZ: Cinder_DZE {};
 	
-	class MetalFloor_Preview_DZ: FloorsWallsStairs { //fix for broken offsets in ghost
+	class MetalFloor_Preview_DZ: FloorsWallsStairs {
 		points[] = {
 		{0,0,0.011,"Pivot"},
-		{0, -2.64, 0.009,"Back"},
-		{0, 2.64, 0.009,"Front"},
-		{-2.64, 0, 0.009,"Left"},
-		{2.64, 0, 0.009,"Right"}
+		{0, -2.64, 0.025,"Back"},
+		{0, 2.64, 0.025,"Front"},
+		{-2.64, 0, 0.025,"Left"},
+		{2.64, 0, 0.025,"Right"}
 		};
 		radius = 12;
 	};
 	class MetalFloor_DZ: FloorsWallsStairs{
 		points[] = {
 		{0,0,0,"Pivot"},
-		{0, -2.64, 0.15,"Back"},
-		{0, 2.64, 0.15,"Front"},
-		{-2.64, 0, 0.15,"Left"},
-		{2.64, 0, 0.15,"Right"}
+		{0, -2.64, 0.025,"Back"},
+		{0, 2.64, 0.025,"Front"},
+		{-2.64, 0, 0.025,"Left"},
+		{2.64, 0, 0.025,"Right"}
 		};
 		radius = 12;
 	};
-	
 	
 	//Non essential Items that only snap to themselves, do whitelist inheritance if you want these to snap
 	class WoodCrate_DZ {

--- a/SQF/dayz_code/Configs/CfgMagazines/DZE/Misc.hpp
+++ b/SQF/dayz_code/Configs/CfgMagazines/DZE/Misc.hpp
@@ -885,7 +885,7 @@ class CinderBlocks: CA_Magazine
 			script = ";['Crafting','CfgMagazines', _id] spawn player_craftItem; r_action_count = r_action_count + 1;";
 			neednearby[] = {"workshop"};
 			requiretools[] = {"ItemToolbox"};
-			output[] = {{"cinder_wall_kit",1}};
+			output[] = {{"half_cinder_wall_kit",1}};
 			input[] = {{"CinderBlocks",3},{"MortarBucket",1}};
 		};
 		class Crafting1

--- a/SQF/dayz_code/Configs/CfgMagazines/DZE/ModularBuilding.hpp
+++ b/SQF/dayz_code/Configs/CfgMagazines/DZE/ModularBuilding.hpp
@@ -17,7 +17,7 @@ class metal_floor_kit: CA_Magazine {
 	};
 };
 
-class cinder_wall_kit: CA_Magazine {
+class half_cinder_wall_kit: CA_Magazine {
 	scope = public;
 	count = 1;
 	type = 256;

--- a/SQF/dayz_code/stringtable.xml
+++ b/SQF/dayz_code/stringtable.xml
@@ -11614,13 +11614,13 @@
 			<Czech>Stavba zrušena.</Czech>
 		</Key>
 		<Key ID="STR_EPOCH_PLAYER_47">
-			<English>Canceled construction of %1 %2.</English>
-			<German>Bau von %1 %2 abgebrochen.</German>
-			<Russian>Отменено строительство %1 %2.</Russian>
+			<English>Canceled construction of %1, %2.</English>
+			<German>Bau von %1, %2 abgebrochen.</German>
+			<Russian>Отменено строительство %1, %2.</Russian>
 			<!-- <Spanish></Spanish> -->
-			<Dutch>Gestopt met het bouwen van %1 %2.</Dutch>
-			<French>La construction de %1 %2 est annulée.</French>
-			<Czech>Stavba %1 %2 byla zrušena.</Czech>
+			<Dutch>Gestopt met het bouwen van %1, %2.</Dutch>
+			<French>La construction de %1, %2 est annulée.</French>
+			<Czech>Stavba %1, %2 byla zrušena.</Czech>
 		</Key>
 		<Key ID="STR_EPOCH_PLAYER_48">
 			<English>Downgrade already in progress.</English>


### PR DESCRIPTION
This correctly fixes snap points for all cinder related to metal floors, especially full cinder walls.

Anything cinder will now correctly snap to full cinder walls and vice versa

Metal floors will not have gaps so you can correctly create a 1x1 cube (as it should be)

Renamed cinder_wall_kit to half_cinder_wall_kit to be in line with full_cinder_wall_kit since I felt it was confusing. cinder_wall_kit seems like it would be full to me.

Fixed a string issue when cancelling building to make it more readable.