### PR TITLE
Advanced trading tidyness

### DIFF
--- a/SQF/dayz_code/actions/AdvancedTrading/functions/z_at_buyItems.sqf
+++ b/SQF/dayz_code/actions/AdvancedTrading/functions/z_at_buyItems.sqf
@@ -2,6 +2,8 @@ private ["_magazinesToBuy", "_weaponsToBuy", "_backpacksToBuy", "_toolsToBuy", "
 ,"_enoughMoney", "_myMoney", "_canBuy", "_moneyInfo","_count","_success","_backpack","_toolClasses","_itemsToLog","_tCost","_bTotal"
 ];
 
+if (count Z_BuyingArray < 1) exitWith { systemChat localize "STR_EPOCH_TRADE_BUY_NO_ITEMS"; };
+
 _magazinesToBuy = 0;
 _weaponsToBuy = 0;
 _backpacksToBuy = 0;
@@ -9,13 +11,10 @@ _toolsToBuy = 0;
 _sidearmToBuy = 0;
 _primaryToBuy = 0;
 _vehiclesToBuy = 0;
-_bTotal = 0;
 
 _priceToBuy = 0;
 _toolClasses = [];
 _itemsToLog = [[],[],[],"buy"];
-
-if (count Z_BuyingArray < 1) exitWith { systemChat localize "STR_EPOCH_TRADE_BUY_NO_ITEMS"; };
 
 if (Z_SingleCurrency) then {
 	{
@@ -106,6 +105,7 @@ if (Z_SingleCurrency) then {
 
 if(_enoughMoney) then {
 	if(_canBuy) then {
+	_bTotal = 0;
 		_buyVehicle = {
 			private "_location";
 			_part_out = _this select 0;
@@ -151,19 +151,17 @@ if(_enoughMoney) then {
 			{
 				if( _x select 1 == "trade_weapons")then{
 					_backpack addWeaponCargoGlobal [_x select 0, _x select 9];
-					_bTotal = _bTotal + (_x select 9);
 				};
 				if( _x select 1 == "trade_items")then{
 					_backpack addMagazineCargoGlobal  [_x select 0, _x select 9];
-					_bTotal = _bTotal + (_x select 9);
 				};				
 				if((_x select 1) in ["trade_any_vehicle", "trade_any_vehicle_free", "trade_any_vehicle_old", "trade_any_bicycle", "trade_any_bicycle_old", "trade_any_boat", "trade_any_boat_old"])then{
 					_item2Add = [(_x select 0), (_x select 1)] call _buyVehicle;
-					_bTotal = _bTotal + (_x select 9);
 					if (_item2Add != "0") then {
 						_backpack addWeaponCargoGlobal  [_item2Add, 1];
 					};
 				};
+				_bTotal = _bTotal + (_x select 9);
 			} count Z_BuyingArray;
 			systemChat format[localize "STR_EPOCH_TRADE_BUY_IN_BACKPACK",_bTotal];
 		};
@@ -172,23 +170,20 @@ if(_enoughMoney) then {
 			{
 				if( _x select 1 == "trade_weapons")then{
 					Z_vehicle addWeaponCargoGlobal [_x select 0, _x select 9];
-					_bTotal = _bTotal + (_x select 9);
 				};
 				if( _x select 1 == "trade_items")then{
 					Z_vehicle addMagazineCargoGlobal [_x select 0, _x select 9];
-					_bTotal = _bTotal + (_x select 9);
 				};
 				if( _x select 1 == "trade_backpacks")then{
 					Z_vehicle addBackpackCargoGlobal [_x select 0, _x select 9];
-					_bTotal = _bTotal + (_x select 9);
 				};
 				if((_x select 1) in ["trade_any_vehicle", "trade_any_vehicle_free", "trade_any_vehicle_old", "trade_any_bicycle", "trade_any_bicycle_old", "trade_any_boat", "trade_any_boat_old"])then{
 					_item2Add = [(_x select 0), (_x select 1)] call _buyVehicle;
-					_bTotal = _bTotal + (_x select 9);
 					if (_item2Add != "0") then {
 						Z_vehicle addWeaponCargoGlobal [_item2Add, 1];
 					};
 				};
+				_bTotal = _bTotal + (_x select 9);
 			} count Z_BuyingArray;
 			systemChat format[localize "STR_EPOCH_TRADE_BUY_IN_VEHICLE",_bTotal,typeOf Z_vehicle];
 		};
@@ -201,7 +196,6 @@ if(_enoughMoney) then {
 						player addWeapon (_x select 0);
 						_count = _count + 1;
 					};
-					_bTotal = _bTotal + (_x select 9);
 				};
 				if( _x select 1 == "trade_items" ) then {
 					_count = 0;
@@ -209,19 +203,17 @@ if(_enoughMoney) then {
 						player addMagazine (_x select 0);
 						_count = _count + 1;
 					};
-					_bTotal = _bTotal + (_x select 9);
 				};
 				if( _x select 1 == "trade_backpacks")then{
 					player addBackpack (_x select 0);
-					_bTotal = _bTotal + (_x select 9);
 				};
 				if((_x select 1) in ["trade_any_vehicle", "trade_any_vehicle_free", "trade_any_vehicle_old", "trade_any_bicycle", "trade_any_bicycle_old", "trade_any_boat", "trade_any_boat_old"])then{
 					_item2Add = [(_x select 0), (_x select 1)] call _buyVehicle;
-					_bTotal = _bTotal + (_x select 9);
 					if (_item2Add != "0") then {
 						player addWeapon _item2Add;
 					};
 				};
+				_bTotal = _bTotal + (_x select 9);
 			} count Z_BuyingArray;
 			systemChat format[localize "STR_EPOCH_TRADE_BUY_IN_GEAR",_bTotal];
 		};

--- a/SQF/dayz_code/actions/AdvancedTrading/functions/z_at_calcPrice.sqf
+++ b/SQF/dayz_code/actions/AdvancedTrading/functions/z_at_calcPrice.sqf
@@ -3,7 +3,7 @@
 *
 *	Calculate the total price for single currency.
 **/
-private ["_sellPrice","_ctrltext"];
+private ["_sellPrice","_ctrltext","_bTotal"];
 #include "defines.hpp"
 
 _sellPrice = 0;
@@ -30,11 +30,15 @@ if(Z_SingleCurrency) then {
 					_sellPrice = _sellPrice +  ((_x select 2) * (_x select 11));
 			}count Z_SellArray;
 			_ctrltext = _sellPrice call Z_calcDefaultCurrency;
+			(findDisplay Z_AT_DIALOGWINDOW displayCtrl Z_AT_RIGHTLISTTITLE) ctrlSetText format ["%1 (%2 items)", localize "STR_EPOCH_TRADE_SELLING", count Z_SellArray];
 		} else {
+			_bTotal = 0;
 			{
 					_sellPrice = _sellPrice +  ((_x select 2) * (_x select 11) * (_x select 9));
+					_bTotal = _bTotal + (_x select 9);
 			}count Z_BuyingArray;
 				_ctrltext = _sellPrice call Z_calcDefaultCurrency;
+				(findDisplay Z_AT_DIALOGWINDOW displayCtrl Z_AT_RIGHTLISTTITLE) ctrlSetText format ["%1 (%2 items)", localize "STR_EPOCH_TRADE_BUYING", _bTotal];
 		};
 		ctrlSetText [Z_AT_PRICEDISPLAY, ''];
 		(findDisplay Z_AT_DIALOGWINDOW displayCtrl Z_AT_PRICEINFO) ctrlSetStructuredText parseText _ctrltext;

--- a/SQF/dayz_code/actions/AdvancedTrading/functions/z_at_logTrade.sqf
+++ b/SQF/dayz_code/actions/AdvancedTrading/functions/z_at_logTrade.sqf
@@ -25,9 +25,9 @@ _Z_logTrade = {
 		};
 	} else {
 		if (_buyOrSell == "buy") then {
-			diag_log format["%5: Bought %4 x %1 into %7 at %2 for %3",_className,inTraderCity,_tcost,_quantity,localize "STR_EPOCH_PLAYER_289",_currency,_container];
+			diag_log format["%5: Bought %4 x %1 into %7 at %2 for%3",_className,inTraderCity,_tcost,_quantity,localize "STR_EPOCH_PLAYER_289",_currency,_container];
 		} else {
-			diag_log format["%5: Sold %4 x %1 from %7 at %2 for %3",_className,inTraderCity,_tcost,_quantity,localize "STR_EPOCH_PLAYER_289",_currency,_container];
+			diag_log format["%5: Sold %4 x %1 from %7 at %2 for%3",_className,inTraderCity,_tcost,_quantity,localize "STR_EPOCH_PLAYER_289",_currency,_container];
 		};
 	};	
 


### PR DESCRIPTION
Optimizes the code for the buyitems item listing (What was I thinking!)
Adds item count to buy/sell list (Useful for checking against backpack/vehicle storage space constraints when buying multiple items)
Small logging fix.
Moves buying check to start of SQF to save time (As per what @ebaydayz did on the sellitems SQF)