### PR TITLE
Advanced trading fixes, plot/door management sorting

### DIFF
--- a/SQF/dayz_code/actions/AdvancedTrading/functions/z_at_allowBuying.sqf
+++ b/SQF/dayz_code/actions/AdvancedTrading/functions/z_at_allowBuying.sqf
@@ -2,7 +2,7 @@ private ["_selection","_return","_toBuyWeaps","_toBuyTotalMags","_toBuyBags","_t
 ,"_primaryToBuy","_currentPrimarys","_p","_b","_check0","_check1","_check2","_check3","_check4","_allowedMags"
 ,"_allowedPrimary","_allowedTools","_allowedSidearm","_allowedBackpacks","_parentClasses","_toolClasses"
 ,"_duplicate","_quantity","_tool","_totalBagSlots","_pistolMags","_regularMags","_toBuyPistolMags"
-,"_toBuyRegularMags","_type","_freeSpace","_backpack","_totalSpace"
+,"_toBuyRegularMags","_type","_freeSpace","_backpack"
 ];
 _selection = Z_SellingFrom;
 _return = false;
@@ -27,7 +27,7 @@ if (_vehiclesToBuy > 0) then {
 
 if (_selection == 2) then { //gear
 	_pistolMags = 0;
-	_regularMags = 0;	
+	_regularMags = 0;
 	{
 		_type = getNumber (configFile >> "CfgMagazines" >> _x >> "type");
 		if (_type == 16) then {_pistolMags = _pistolMags + 1;}; // 16 = WeaponSlotHandGunItem (pistol ammo slot)
@@ -132,7 +132,6 @@ if (_selection == 1) then { //vehicle
 };
 
 if (_selection == 0) then { //backpack
-	_totalSpace = 0;
 	_totalBagSlots = 0;
 
 	_backpack = unitBackpack player;
@@ -140,7 +139,6 @@ if (_selection == 0) then { //backpack
 	if (!isNull _backpack) then {
 		_check0 = true;
 		_freeSpace = [_backpack,_primaryToBuy,_sidearmToBuy,_toolsToBuy,_toBuyTotalMags] call Z_calcFreeSpace;
-		_totalSpace = _freeSpace select 0;
 		_allowedMags = _freeSpace select 1;
 		_allowedWeapons = _freeSpace select 2;
 		_totalBagSlots = _freeSpace select 4;
@@ -162,18 +160,13 @@ if (_selection == 0) then { //backpack
 		_check2 = true;
 	} else {
 		systemChat format[localize "STR_EPOCH_TRADE_BAG_MAGS", _allowedMags];
+		
 	};
 	if (_toBuyBags < 1) then { // A backpack can not hold any backpacks
 		_check3 = true;
 	};
 
-	if (_totalSpace <= _totalBagSlots) then {
-		_check4 = true;
-	} else {
-		systemChat localize "STR_EPOCH_TRADE_BACKPACK_FULL";
-	};
-
-	if (_check0 && _check1 && _check2 && _check3 && _check4) then { _return = true; };
+	if (_check0 && _check1 && _check2 && _check3) then { _return = true; };
 };
 
 _return

--- a/SQF/dayz_code/actions/AdvancedTrading/functions/z_at_buyItems.sqf
+++ b/SQF/dayz_code/actions/AdvancedTrading/functions/z_at_buyItems.sqf
@@ -96,6 +96,8 @@ if (Z_SingleCurrency) then {
 
 _canBuy = [_weaponsToBuy,[_pistolMagsToBuy,_regularMagsToBuy],_backpacksToBuy,_toolsToBuy,_sidearmToBuy,_primaryToBuy,_vehiclesToBuy,_toolClasses] call Z_allowBuying;
 
+if (!_canBuy) exitWith {};
+
 _myMoney = player getVariable[Z_MoneyVariable,0];
 
 _enoughMoney = false;

--- a/SQF/dayz_code/actions/doorManagement/doorNearbyHumans.sqf
+++ b/SQF/dayz_code/actions/doorManagement/doorNearbyHumans.sqf
@@ -1,6 +1,8 @@
-private ["_closePeople","_friendUID","_friendName"];
+private ["_closePeople","_friendUID","_friendName","_lb"];
+disableSerialization;
 
-lbClear 7101;
+_lb = (findDisplay 711195) displayCtrl 7101;
+lbClear _lb;
 _closePeople =  player nearEntities ["CAManBase", 10];
 if (!DZE_doorManagementMustBeClose) then {_closePeople = playableUnits};
 Humans = [];
@@ -9,6 +11,8 @@ Humans = [];
 		_friendUID = [_x] call FNC_GetPlayerUID;
 		_friendName = name  _x;
 		Humans set [count Humans, [_friendUID,_friendName]];
-		lbAdd [7101, _friendName];
+		_lb lbAdd _friendName;
 	};
 } forEach _closePeople;
+
+lbSort _lb;

--- a/SQF/dayz_code/actions/plotManagement/plotNearbyHumans.sqf
+++ b/SQF/dayz_code/actions/plotManagement/plotNearbyHumans.sqf
@@ -1,6 +1,8 @@
-private ["_closePeople","_friendUID","_friendName"];
+private ["_closePeople", "_friendUID","_friendName","_lb"];
+disableSerialization;
 
-lbClear 7001;
+_lb = (findDisplay 711194) displayCtrl 7001;
+lbClear _lb;
 if (!DZE_plotManagementMustBeClose) then {_closePeople = playableUnits;} else {_closePeople = player nearEntities ["CAManBase", 10];};
 Humans = [];
 {
@@ -8,6 +10,8 @@ Humans = [];
 		_friendUID = [_x] call FNC_GetPlayerUID;
 		_friendName = name _x;
 		Humans  =  Humans + [[_friendUID,_friendName]];
-		lbAdd [7001, _friendName];
+		_lb lbAdd _friendName;
 	};
-} forEach _closePeople; // count causes Error Type Number, expected Bool here
+} forEach _closePeople;
+
+lbSort _lb;

--- a/SQF/dayz_code/stringtable.xml
+++ b/SQF/dayz_code/stringtable.xml
@@ -16202,9 +16202,6 @@
 			<English>You can only buy %1 backpacks into your vehicle.</English>
 			<Russian>Вы можете купить рюкзаков в ваш транспорт: %1.</Russian>
 		</Key>
-		<Key ID="STR_EPOCH_TRADE_BACKPACK_FULL">
-			<English>Total backpack space exceeded.</English>
-		</Key>
 		<Key ID="STR_EPOCH_TRADE_BAG_WEPS">
 			<English>Only %1 weapons will fit into your backpack.</English>
 			<Russian>В рюкзак поместится оружия: %1.</Russian>


### PR DESCRIPTION
Added sorting to the players online list on plot management and door management.
Removes redundant backpack full space check since the gun/mag check takes care of this already.
Added an exit after doing the allowBuying check so it doesn't repeat that stuff can't fit in your bag