### PR TITLE
Advanced trading tidyness

### DIFF
--- a/SQF/dayz_code/actions/AdvancedTrading/functions/z_at_displayVehicleInfo.sqf
+++ b/SQF/dayz_code/actions/AdvancedTrading/functions/z_at_displayVehicleInfo.sqf
@@ -117,14 +117,14 @@ _wepText = "";
 if (Z_SingleCurrency) then {
 	_formattedText = format [
 	"<img image='%1' size='3' /><br />" +
-	"<t color='#33BFFF' size='0.8'>%10: </t><t color='#ffffff' size='0.7'>%2</t><br />" +
-	"<t color='#33BFFF' size='0.8'>%11: </t><t color='#ffffff' size='0.7'>%3</t><br />" +
+	"<t color='#33BFFF' size='0.8'>%10: </t><t color='#ffffff' size='0.8'>%2</t><br />" +
+	"<t color='#33BFFF' size='0.8'>%11: </t><t color='#ffffff' size='0.8'>%3</t><br />" +
 	"<t color='#33BFFF' size='0.8'>%13: </t><t color='#ffffff' size='0.8'>%6 %7</t><br />" +
 	"<t color='#33BFFF' size='0.8'>%12: </t><t color='#ffffff' size='0.8'>%5 %7</t><br />" +
 	"<t color='#33BFFF' size='0.8'>%14/%15/%16: </t><t color='#ffffff' size='0.8'>%9/%8/%4</t><br />" +
 	"<t color='#33BFFF' size='0.8'>%17: </t><t color='#ffffff' size='0.8'>%18  </t><t color='#33BFFF' size='0.8'>%24: </t><t color='#ffffff' size='0.8'>%25</t><br />" + // Armor / Seats
 	"<t color='#33BFFF' size='0.8'>%21%22: </t><t color='#ffffff' size='0.8'>%23  </t><t color='#33BFFF' size='0.8'>%19: </t><t color='#ffffff' size='0.8'>%20</t><br />" + // MaxSpeed / Fuel
-	"<t color='#33BFFF' size='0.8'>%26: </t><t color='#ffffff' size='0.7'>%27</t>" // Weapons
+	"<t color='#33BFFF' size='0.8'>%26: </t><t color='#ffffff' size='0.8'>%27</t>" // Weapons
 	, _picture, _display, _class, _transportmaxBackpacks, _sellPrice, _buyPrice, CurrencyName, _transportMaxWeapons,_transportMaxMagazines, localize "STR_EPOCH_NAME", localize "STR_EPOCH_CLASS", localize "STR_EPOCH_PLAYER_292", localize "STR_EPOCH_PLAYER_291", localize "STR_EPOCH_MAGS", localize "STR_EPOCH_WEPS", localize "STR_EPOCH_BAGS",
 	localize "STR_EPOCH_ARMOR",_armor,localize "STR_EPOCH_FUEL",_fuelCapacity,localize "STR_EPOCH_MAX",localize "STR_EPOCH_SPEED",_maxSpeed,localize "STR_EPOCH_SEATS",_seats,localize "STR_EPOCH_WEAPONS",_wepText
 	];
@@ -136,14 +136,14 @@ if (Z_SingleCurrency) then {
 
 	_formattedText = format [
 	"<img image='%1' size='3' /><br />" +
-	"<t color='#33BFFF' size='0.8'>%13: </t><t color='#ffffff' size='0.7'>%2</t><br />" +
-	"<t color='#33BFFF' size='0.8'>%14: </t><t color='#ffffff' size='0.7'>%3</t><br />" +
+	"<t color='#33BFFF' size='0.8'>%13: </t><t color='#ffffff' size='0.8'>%2</t><br />" +
+	"<t color='#33BFFF' size='0.8'>%14: </t><t color='#ffffff' size='0.8'>%3</t><br />" +
 	"<t color='#33BFFF' size='0.8'>%16: </t><t color='#ffffff' size='0.8'>%6 <img image='%12' /> %7</t><br />" +
 	"<t color='#33BFFF' size='0.8'>%15: </t><t color='#ffffff' size='0.8'>%5 <img image='%11' /> %10</t><br />" +
 	"<t color='#33BFFF' size='0.8'>%17/%18/%19: </t><t color='#ffffff' size='0.8'>%8/%9/%4</t><br />" +
 	"<t color='#33BFFF' size='0.8'>%20: </t><t color='#ffffff' size='0.8'>%21  </t><t color='#33BFFF' size='0.8'>%27: </t><t color='#ffffff' size='0.8'>%28</t><br />" + // Armor / Seats
 	"<t color='#33BFFF' size='0.8'>%24%25: </t><t color='#ffffff' size='0.8'>%26  </t><t color='#33BFFF' size='0.8'>%22: </t><t color='#ffffff' size='0.8'>%23</t><br />" + // MaxSpeed  /  Fuel
-	"<t color='#33BFFF' size='0.8'>%29: </t><t color='#ffffff' size='0.7'>%30</t>" // Weapons
+	"<t color='#33BFFF' size='0.8'>%29: </t><t color='#ffffff' size='0.8'>%30</t>" // Weapons
 	, _picture, _display, _class, _transportmaxBackpacks, _sellPrice, _buyPrice, _buyCurrency, _transportMaxWeapons,_transportMaxMagazines, _sellCurrency, _picSell,_picBuy, localize "STR_EPOCH_NAME", localize "STR_EPOCH_CLASS", localize "STR_EPOCH_PLAYER_292", localize "STR_EPOCH_PLAYER_291", localize "STR_EPOCH_WEPS", localize "STR_EPOCH_MAGS", localize "STR_EPOCH_BAGS",
 	localize "STR_EPOCH_ARMOR",_armor,localize "STR_EPOCH_FUEL",_fuelCapacity,localize "STR_EPOCH_MAX",localize "STR_EPOCH_SPEED",_maxSpeed,localize "STR_EPOCH_SEATS",_seats,localize "STR_EPOCH_WEAPONS",_wepText
 	];

--- a/SQF/dayz_code/stringtable.xml
+++ b/SQF/dayz_code/stringtable.xml
@@ -16133,10 +16133,10 @@
 			<Russian>Нет информации</Russian>
 		</Key>
 		<Key ID="STR_EPOCH_TRADE_BUY_NO_ITEMS">
-			<English>No items in buy list</English>
+			<English>No items in buying list</English>
 		</Key>
 		<Key ID="STR_EPOCH_TRADE_SELL_NO_ITEMS">
-			<English>No items in sell list</English>
+			<English>No items in selling list</English>
 			<Russian>Нет ничего на продажу</Russian>
 		</Key>
 		<Key ID="STR_EPOCH_TRADE_DETAILS">
@@ -16209,11 +16209,11 @@
 			<English>Total backpack space exceeded.</English>
 		</Key>
 		<Key ID="STR_EPOCH_TRADE_BAG_MAGS">
-			<English>Only %1 mags will fit into your backpack.</English>
+			<English>You can only buy %1 magazines into your backpack.</English>
 			<Russian>В рюкзак поместится предметов: %1.</Russian>
 		</Key>
 		<Key ID="STR_EPOCH_TRADE_BAG_WEPS">
-			<English>Only %1 weapons will fit into your backpack.</English>
+			<English>You can only buy %1 weapons into your backpack.</English>
 			<Russian>В рюкзак поместится оружия: %1.</Russian>
 		</Key>
 		<Key ID="STR_EPOCH_TRADE_BAG_BAGS">
@@ -16290,9 +16290,6 @@
 		</Key>
 		<Key ID="STR_EPOCH_TRADE_SELLING_FROM">
 			<English>Selling from %1.</English>
-		</Key>
-		<Key ID="STR_EPOCH_TRADE_TOTAL_SPACE_SUCCEEDED">
-			<English>Total space succeeded: Mag=1, Tool=1, Side=5, Primary=10 slots and your bag capacity is %1 where you tried %2 slots.</English>
 		</Key>
 		<Key ID="STR_EPOCH_TRADE_CHANGE_IN_BACKPACK">
 			<English>Some change was added to your backpack.</English>


### PR DESCRIPTION
Makes all display vehicle info text the same size, it looked wierd that it was that little bit different.
Changes the bag weapon/mag full string to be in line with the vehicle version (for sanity)
Removes orphaned localization