### PR TITLE
Advance trading fixes

### DIFF
--- a/SQF/dayz_code/actions/AdvancedTrading/functions/z_at_allowBuying.sqf
+++ b/SQF/dayz_code/actions/AdvancedTrading/functions/z_at_allowBuying.sqf
@@ -124,17 +124,29 @@ if (_selection == 1) then { //vehicle
 	if (_allowedWeapons >= (_toBuyWeaps + _toolsToBuy)) then {
 		_check1 = true;
 	} else {
-		systemChat format[localize "STR_EPOCH_TRADE_VEHICLE_WEPS", _allowedWeapons];
+		if (_allowedWeapons > 0) then {
+			systemChat format[localize "STR_EPOCH_TRADE_VEHICLE_WEPS", _allowedWeapons];
+		} else {
+			systemChat localize "STR_EPOCH_TRADE_VEHICLE_FULL_GUNS";
+		};
 	};
 	if (_allowedMags >= _toBuyTotalMags) then {
 		_check2 = true;
 	} else {
-		systemChat format[localize "STR_EPOCH_TRADE_VEHICLE_MAGS", _allowedMags];
+		if (_allowedMags > 0) then {
+			systemChat format[localize "STR_EPOCH_TRADE_VEHICLE_MAGS", _allowedMags];
+		} else {
+			systemChat localize "STR_EPOCH_TRADE_VEHICLE_FULL_MAGS";
+		};
 	};
 	if (_allowedBackpacks >= _toBuyBags) then {
 		_check3 = true;
 	} else {
-		systemChat format[localize "STR_EPOCH_TRADE_VEHICLE_BAGS", _allowedBackpacks];
+		if (_allowedBackpacks > 0) then {
+			systemChat format[localize "STR_EPOCH_TRADE_VEHICLE_BAGS", _allowedBackpacks];
+		} else {
+			systemChat localize "STR_EPOCH_TRADE_VEHICLE_FULL_BAGS";
+		};
 	};
 
 	if (_check1 && _check2 && _check3) then { _return = true; };
@@ -165,7 +177,11 @@ if (_selection == 0) then { //backpack
 	if (_allowedWeapons >= _toBuyWeaps) then { //_toBuyWeaps does not include tools (which can exceed transportMaxWeapons in backpacks but not vehicles)
 		_check1 = true;
 	} else {
-		systemChat format[localize "STR_EPOCH_TRADE_BAG_WEPS", _allowedWeapons];
+		if (_allowedWeapons > 0) then {
+			systemChat format[localize "STR_EPOCH_TRADE_BAG_WEPS", _allowedWeapons];
+		} else {
+			systemChat localize "STR_EPOCH_TRADE_BACKPACK_FULL";
+		};
 	};
 	
 	if (_allowedMags >= _toBuyTotalMags) then {

--- a/SQF/dayz_code/actions/AdvancedTrading/functions/z_at_checkCloseVehicle.sqf
+++ b/SQF/dayz_code/actions/AdvancedTrading/functions/z_at_checkCloseVehicle.sqf
@@ -4,11 +4,11 @@ Z_vehicle = objNull;
 _vehicle = objNull;
 _pos = [player] call FNC_GetPos;
 _list = nearestObjects [_pos, ["Air","LandVehicle","Ship"], Z_VehicleDistance];
-{
-	if (!isNull _x && local _x && alive _x) then {
-		_vehicle = _x;
-	};
-} count _list;
+
+if (!isNull DZE_myVehicle && local DZE_myVehicle && alive DZE_myVehicle && DZE_myVehicle in _list) then {
+	_vehicle = DZE_myVehicle;
+};
+
 _result = false;
 
 if (!isNull _vehicle) then {

--- a/SQF/dayz_code/actions/AdvancedTrading/functions/z_at_getVehicleItems.sqf
+++ b/SQF/dayz_code/actions/AdvancedTrading/functions/z_at_getVehicleItems.sqf
@@ -1,7 +1,7 @@
 /**
 *	call Z_getVehicleItems
 *
-*	Gets all your items stored in your vehicle and innitiates the selling list.
+*	Gets all your items stored in your vehicle and initiates the selling list.
 **/
 private ["_vehicle","_pos","_list","_formattedText","_pic","_normalMags","_normalWeaps","_freeSpace"];
 #include "defines.hpp"
@@ -14,14 +14,12 @@ _vehicle = objNull;
 
 _pos = [player] call FNC_GetPos;
 _list = nearestObjects [_pos, ["Air","LandVehicle","Ship"], Z_VehicleDistance];
-{
-	if (!isNull _x && local _x && alive _x) then {
-		_vehicle = _x;
-	};
-} count _list;
+
+if (!isNull DZE_myVehicle && local DZE_myVehicle && alive DZE_myVehicle && DZE_myVehicle in _list) then {
+	_vehicle = DZE_myVehicle;
+};
 
 if (!isNull _vehicle) then {
-	systemChat format[localize "STR_EPOCH_TRADE_SELECTED",typeOf _vehicle];
 	_pic = getText (configFile >> 'CfgVehicles' >> (typeOf _vehicle) >> 'picture');
 
 	_formattedText = format [

--- a/SQF/dayz_code/compile/fn_selfActions.sqf
+++ b/SQF/dayz_code/compile/fn_selfActions.sqf
@@ -113,43 +113,46 @@ if (!_canDoThis && s_player_Drinkfromhands >= 0) then {
 	s_player_Drinkfromhands = -1;
 };
 
-if (_inVehicle && {_vehicleOwnerID != "0"} && {!(_vehicle isKindOf "Bicycle")}) then {
-	if (s_player_lockUnlockInside_ctrl < 0) then {
-		DZE_myVehicle = _vehicle;
-		_totalKeys = call epoch_tempKeys;
-		_temp_keys = _totalKeys select 0;
-		_temp_keys_names = _totalKeys select 1;		
-		_hasKey = _vehicleOwnerID in _temp_keys;
-		_oldOwner = (_vehicleOwnerID == dayz_playerUID);
-		_text = getText (configFile >> "CfgVehicles" >> (typeOf DZE_myVehicle) >> "displayName");
-		if (locked DZE_myVehicle) then {
-			if (_hasKey || _oldOwner) then {
-				_unlock = DZE_myVehicle addAction [format[localize "STR_EPOCH_ACTIONS_UNLOCK",_text], "\z\addons\dayz_code\actions\unlock_veh.sqf",[DZE_myVehicle,(_temp_keys_names select (parseNumber _vehicleOwnerID))], 2, true, true];
-				s_player_lockUnlockInside set [count s_player_lockUnlockInside,_unlock];
-				s_player_lockUnlockInside_ctrl = 1;
-			} else {
-				if (_hasHotwireKit) then {
-					_unlock = DZE_myVehicle addAction [format[localize "STR_EPOCH_ACTIONS_HOTWIRE",_text], "\z\addons\dayz_code\actions\hotwire_veh.sqf",DZE_myVehicle, 2, true, true];
+if (_inVehicle) then {
+	DZE_myVehicle = _vehicle;
+	if (_vehicleOwnerID != "0" && !(_vehicle isKindOf "Bicycle")) then {
+		if (s_player_lockUnlockInside_ctrl < 0) then {
+			_totalKeys = call epoch_tempKeys;
+			_temp_keys = _totalKeys select 0;
+			_temp_keys_names = _totalKeys select 1;	
+			_hasKey = _vehicleOwnerID in _temp_keys;
+			_oldOwner = (_vehicleOwnerID == dayz_playerUID);
+			_text = getText (configFile >> "CfgVehicles" >> (typeOf DZE_myVehicle) >> "displayName");
+			if (locked DZE_myVehicle) then {
+				if (_hasKey || _oldOwner) then {
+					_unlock = DZE_myVehicle addAction [format[localize "STR_EPOCH_ACTIONS_UNLOCK",_text], "\z\addons\dayz_code\actions\unlock_veh.sqf",[DZE_myVehicle,(_temp_keys_names select (parseNumber _vehicleOwnerID))], 2, true, true];
+					s_player_lockUnlockInside set [count s_player_lockUnlockInside,_unlock];
+					s_player_lockUnlockInside_ctrl = 1;
 				} else {
-					_unlock = DZE_myVehicle addAction [format["<t color='#ff0000'>%1</t>",localize "STR_EPOCH_ACTIONS_VEHLOCKED"], "",DZE_myVehicle, 2, true, true];
+					if (_hasHotwireKit) then {
+						_unlock = DZE_myVehicle addAction [format[localize "STR_EPOCH_ACTIONS_HOTWIRE",_text], "\z\addons\dayz_code\actions\hotwire_veh.sqf",DZE_myVehicle, 2, true, true];
+					} else {
+						_unlock = DZE_myVehicle addAction [format["<t color='#ff0000'>%1</t>",localize "STR_EPOCH_ACTIONS_VEHLOCKED"], "",DZE_myVehicle, 2, true, true];
+					};
+					s_player_lockUnlockInside set [count s_player_lockUnlockInside,_unlock];
+					s_player_lockUnlockInside_ctrl = 1;
 				};
-				s_player_lockUnlockInside set [count s_player_lockUnlockInside,_unlock];
-				s_player_lockUnlockInside_ctrl = 1;
-			};
-		} else {
-			if (_hasKey || _oldOwner) then {
-				_lock = DZE_myVehicle addAction [format[localize "STR_EPOCH_ACTIONS_LOCK",_text], "\z\addons\dayz_code\actions\lock_veh.sqf",DZE_myVehicle, 1, true, true];
-				s_player_lockUnlockInside set [count s_player_lockUnlockInside,_lock];
-				s_player_lockUnlockInside_ctrl = 1;
+			} else {
+				if (_hasKey || _oldOwner) then {
+					_lock = DZE_myVehicle addAction [format[localize "STR_EPOCH_ACTIONS_LOCK",_text], "\z\addons\dayz_code\actions\lock_veh.sqf",DZE_myVehicle, 1, true, true];
+					s_player_lockUnlockInside set [count s_player_lockUnlockInside,_lock];
+					s_player_lockUnlockInside_ctrl = 1;
+				};
 			};
 		};
-	};
-} else {
-	if (!isNil "DZE_myVehicle") then {
-		{DZE_myVehicle removeAction _x} count s_player_lockUnlockInside;s_player_lockUnlockInside = [];
-		s_player_lockUnlockInside_ctrl = -1;
+	} else {
+		if (!isNil "DZE_myVehicle") then {
+			{DZE_myVehicle removeAction _x} count s_player_lockUnlockInside;s_player_lockUnlockInside = [];
+			s_player_lockUnlockInside_ctrl = -1;
+		};
 	};
 };
+
 
 if (DZE_HeliLift) then {
 	_hasAttached = _vehicle getVariable["hasAttached",false];
@@ -421,8 +424,8 @@ if (!isNull _cursorTarget && !_inVehicle && !_isPZombie && (player distance _cur
 
 		if(_isModular || _isModularDoor || {_typeOfCursorTarget in DZE_isDestroyableStorage}) then {
 			if(_hasToolbox && "ItemCrowbar" in _itemsPlayer) then {
-				_isowner = [player, _cursorTarget] call FNC_check_access;
-				if ((_isowner select 0) or (_isowner select 2) or (_isowner select 3)) then {
+				_isOwner = [player, _cursorTarget] call FNC_check_access;
+				if ((_isOwner select 0) or (_isOwner select 2) or (_isOwner select 3)) then {
 					_player_deleteBuild = true;
 				};
 			};
@@ -502,7 +505,7 @@ if (!isNull _cursorTarget && !_inVehicle && !_isPZombie && (player distance _cur
 		player removeAction s_player_sleep;
 		s_player_sleep = -1;
 	};
-					
+
 	//Study Body
 	if (_isMan && {!_isAlive} && {!_isZombie} && {!_isAnimal}) then {
 		if (s_player_studybody < 0) then {
@@ -634,8 +637,8 @@ if (!isNull _cursorTarget && !_inVehicle && !_isPZombie && (player distance _cur
 	if ((_cursorTarget isKindOf "Plastic_Pole_EP1_DZ") && {_canDo && speed player <= 1}) then {
 		if (DZE_permanentPlot) then {
 			if (s_player_plotManagement < 0) then {
-				_isowner = [player, _cursorTarget] call FNC_check_access;
-				if ((_isowner select 0) or (_isowner select 2) or (_isowner select 3) or (_isowner select 4)) then {
+				_isOwner = [player, _cursorTarget] call FNC_check_access;
+				if ((_isOwner select 0) or (_isOwner select 2) or (_isOwner select 3) or (_isOwner select 4)) then {
 					s_player_plotManagement = player addAction [format["<t color='#0059FF'>%1</t>",localize "STR_EPOCH_ACTIONS_MANAGEPLOT"], "\z\addons\dayz_code\actions\plotManagement\initPlotManagement.sqf", [], 5, false];
 				};
 			};
@@ -659,8 +662,8 @@ if (!isNull _cursorTarget && !_inVehicle && !_isPZombie && (player distance _cur
 		if (DZE_permanentPlot) then {
 			if (s_player_plot_take_ownership < 0) then {
 				if (DZE_PlotOwnership) then {
-					_isowner = [player, _cursorTarget] call FNC_check_access;
-					if (_isowner select 0) then {
+					_isOwner = [player, _cursorTarget] call FNC_check_access;
+					if (_isOwner select 0) then {
 						s_player_plot_take_ownership = player addAction ["Take plot items ownership", "\z\addons\dayz_code\actions\A_Plot_for_Life\plot_take_ownership.sqf", "", 1, false];
 					};
 				};
@@ -769,15 +772,15 @@ if (!isNull _cursorTarget && !_inVehicle && !_isPZombie && (player distance _cur
 	// Allow manage door
 	if( DZE_doorManagement && (_typeOfCursorTarget in DZE_DoorsLocked) ) then {
 		// Check player access
-		_isowner = [player, _cursorTarget] call FNC_check_access;
+		_isOwner = [player, _cursorTarget] call FNC_check_access;
 		if( (s_player_manageDoor < 0) && (
-					((_isowner select 0) && DZE_doorManagementAllowManage_owner) // door owner
-				||	((_isowner select 1) && DZE_doorManagementAllowManage_ownerFriendlies) // door owner's friendly tagged
-				||	((_isowner select 2) && DZE_doorManagementAllowManage_plotOwner) // plot owner
-				||	((_isowner select 3) && DZE_doorManagementAllowManage_plotFriends) // plot friends
-				||	((_isowner select 4) && DZE_doorManagementAllowManage_plotAdmins) // plot management admins
-				||	((_isowner select 5) && DZE_doorManagementAllowManage_doorFriends) // door friends
-				||	((_isowner select 6) && DZE_doorManagementAllowManage_doorAdmins) // door management admins
+					((_isOwner select 0) && DZE_doorManagementAllowManage_owner) // door owner
+				||	((_isOwner select 1) && DZE_doorManagementAllowManage_ownerFriendlies) // door owner's friendly tagged
+				||	((_isOwner select 2) && DZE_doorManagementAllowManage_plotOwner) // plot owner
+				||	((_isOwner select 3) && DZE_doorManagementAllowManage_plotFriends) // plot friends
+				||	((_isOwner select 4) && DZE_doorManagementAllowManage_plotAdmins) // plot management admins
+				||	((_isOwner select 5) && DZE_doorManagementAllowManage_doorFriends) // door friends
+				||	((_isOwner select 6) && DZE_doorManagementAllowManage_doorAdmins) // door management admins
 		)) then {
 			s_player_manageDoor = player addAction [format["<t color='#0059FF'>%1</t>", localize "STR_EPOCH_ACTIONS_MANAGEDOOR"], "\z\addons\dayz_code\actions\doorManagement\initDoorManagement.sqf", _cursorTarget, 5, false];
 		};
@@ -885,9 +888,9 @@ if (!isNull _cursorTarget && !_inVehicle && !_isPZombie && (player distance _cur
 			};
 		};
 		if (s_player_upgrade_build < 0) then {
-			_isowner = [player, _cursorTarget] call FNC_check_access;
+			_isOwner = [player, _cursorTarget] call FNC_check_access;
 			_upgrade = getArray (configFile >> "CfgVehicles" >> (typeOf _cursorTarget) >> "upgradeBuilding");
-			if (((_isowner select 0) or (_isowner select 2) or (_isowner select 3)) && (count _upgrade) > 0) then {
+			if (((_isOwner select 0) or (_isOwner select 2) or (_isOwner select 3)) && (count _upgrade) > 0) then {
 				s_player_lastTarget set [0,_cursorTarget];
 				s_player_upgrade_build = player addAction [format[localize "str_upgrade",_text], "\z\addons\dayz_code\actions\player_upgrade.sqf",_cursorTarget, -1, false, true];
 			};
@@ -906,8 +909,8 @@ if (!isNull _cursorTarget && !_inVehicle && !_isPZombie && (player distance _cur
 			};
 		};
 		if (s_player_downgrade_build < 0) then {
-			_isowner = [player, _cursorTarget] call FNC_check_access;
-			if ((_isowner select 0) or (_isowner select 2) or (_isowner select 3)) then {
+			_isOwner = [player, _cursorTarget] call FNC_check_access;
+			if ((_isOwner select 0) or (_isOwner select 2) or (_isOwner select 3)) then {
 				s_player_lastTarget set [1,_cursorTarget];
 				s_player_downgrade_build = player addAction [format[localize "STR_EPOCH_ACTIONS_REMLOCK",_text], "\z\addons\dayz_code\actions\player_buildingDowngrade.sqf",_cursorTarget, -2, false, true];
 			};
@@ -926,8 +929,8 @@ if (!isNull _cursorTarget && !_inVehicle && !_isPZombie && (player distance _cur
 			};
 		};
 		if (s_player_maint_build < 0) then {
-			_isowner = [player, _cursorTarget] call FNC_check_access;
-			if ((_isowner select 0) or (_isowner select 2) or (_isowner select 3)) then {
+			_isOwner = [player, _cursorTarget] call FNC_check_access;
+			if ((_isOwner select 0) or (_isOwner select 2) or (_isOwner select 3)) then {
 				_text2 = _text + " (" + str(round ((damage _cursorTarget) * 100)) + "% damaged)";
 				s_player_lastTarget set [2,_cursorTarget];
 				s_player_maint_build = player addAction [format["%1 %2",localize "STR_EPOCH_ACTIONS_MAINTAIN",_text2], "\z\addons\dayz_code\actions\player_buildingMaint.sqf",_cursorTarget, -2, false, true];

--- a/SQF/dayz_code/stringtable.xml
+++ b/SQF/dayz_code/stringtable.xml
@@ -16024,7 +16024,7 @@
 			<Russian>Транспорт</Russian>
 			<Spanish>Vehículo</Spanish>
 			<French>Véhicule</French>
-			<Czech>Vozidlo</Czech>			
+			<Czech>Vozidlo</Czech>
 			<Italian>Veicolo</Italian>
 			<Polish>Pojazd</Polish>
 			<Hungarian>Jármű</Hungarian>
@@ -16119,7 +16119,7 @@
 		</Key>
 		<Key ID="STR_EPOCH_TRADE_NOTHING">
 			<English>Nothing</English>
-			<Russian>Ничего</Russian>			
+			<Russian>Ничего</Russian>
 			<French>Rien</French>
 			<Spanish>Nada</Spanish>
 			<Italian>Niente</Italian>
@@ -16208,6 +16208,15 @@
 			<English>You can only buy %1 backpacks into your vehicle.</English>
 			<Russian>Вы можете купить рюкзаков в ваш транспорт: %1.</Russian>
 		</Key>
+		<Key ID="STR_EPOCH_TRADE_VEHICLE_FULL_GUNS">
+			<English>You can't fit anymore weapons into your vehicle.</English>
+		</Key>
+		<Key ID="STR_EPOCH_TRADE_VEHICLE_FULL_MAGS">
+			<English>You can't fit anymore magazines into your vehicle.</English>
+		</Key>
+		<Key ID="STR_EPOCH_TRADE_VEHICLE_FULL_BAGS">
+			<English>You can't fit anymore backpacks into your vehicle.</English>
+		</Key>
 		<Key ID="STR_EPOCH_TRADE_BACKPACK_FULL">
 			<English>Total backpack space exceeded.</English>
 		</Key>
@@ -16275,7 +16284,7 @@
 			<English>You need %1 %2 to buy all these items.</English>
 			<Russian>Вам нужно %1 %2 для покупки.</Russian>
 		</Key>
-		<Key ID="STR_EPOCH_TRADE_NEED_MONEY">		
+		<Key ID="STR_EPOCH_TRADE_NEED_MONEY">
 			<English>Cannot buy: Not enough money!</English>
 			<German>Kauf nicht möglich: Nicht genug Geld!</German>
 			<Italian>Impossibile comprare: servono più soldi!</Italian>


### PR DESCRIPTION
Add more semantics changes so vehicle buying for guns/ammo/bags worked
the same as the backpack.

Checking against local vehicles doesn't work well with Advanced Trading
since a local vehicle is not singular, this changes how Advanced trading
sees your local vehicle by using dze_myVehicle that gets set when you
get into a vehicle.

This will now correctly select the last vehicle you were in, instead of
the first one in the local list.

(You could have 2 vehicles or more at a trader that you were local with
and it would always select the first in the list)