### PR TITLE
Cinder block text changes

### DIFF
--- a/SQF/dayz_code/Configs/CfgVehicles/DZE/ModularBuilding.hpp
+++ b/SQF/dayz_code/Configs/CfgVehicles/DZE/ModularBuilding.hpp
@@ -124,7 +124,7 @@ class CinderWallDoorway_DZ: ModularItems {
 	icon = "\ca\data\data\Unknown_object.paa";
 	mapSize = 2;
 	armor = 3400;
-	displayName = "Block Garage Doorway";
+	displayName = "Cinder Garage Doorway";
 	vehicleClass = "Fortifications";
 	maintainBuilding[] = {{"MortarBucket",1}};
 	upgradeBuilding[] = {"CinderWallDoor_DZ",{{"ItemPole",3},{"ItemTankTrap",3}}};
@@ -150,7 +150,7 @@ class CinderWallSmallDoorway_DZ: ModularItems {
 	icon = "\ca\data\data\Unknown_object.paa";
 	mapSize = 2;
 	armor = 3400;
-	displayName = "Block Doorway";
+	displayName = "Cinder Doorway";
 	vehicleClass = "Fortifications";
 	maintainBuilding[] = {{"MortarBucket",1}};
 	upgradeBuilding[] = {"CinderWallDoorSmall_DZ",{{"ItemPole",1},{"ItemTankTrap",1}}};
@@ -494,7 +494,7 @@ class CinderWallSmallDoorway_Preview_DZ: NonStrategic {
 	icon = "\ca\data\data\Unknown_object.paa";
 	mapSize = 2;
 	armor = 1000;
-	displayName = "Block Doorway Preview";
+	displayName = "Cinder Doorway Preview";
 	vehicleClass = "Fortifications";
 };
 class CinderWallDoorway_Preview_DZ: NonStrategic {
@@ -506,7 +506,7 @@ class CinderWallDoorway_Preview_DZ: NonStrategic {
 	icon = "\ca\data\data\Unknown_object.paa";
 	mapSize = 2;
 	armor = 1000;
-	displayName = "Block Garage Doorway Preview";
+	displayName = "Cinder Garage Doorway Preview";
 	vehicleClass = "Fortifications";
 };
 class MetalFloor_Preview_DZ: NonStrategic {

--- a/SQF/dayz_code/stringtable.xml
+++ b/SQF/dayz_code/stringtable.xml
@@ -16447,12 +16447,12 @@
 			<Czech>Full height cinder block wall.</Czech>
 		</Key>
 		<Key ID="STR_EPOCH_BLOCKDOORWAY">
-			<English>Block Doorway</English>
-			<German>Block Doorway</German>
-			<Russian>Block Doorway</Russian>
-			<Spanish>Block Doorway</Spanish>
-			<French>Block Doorway</French>
-			<Czech>Block Doorway</Czech>
+			<English>Cinder Doorway</English>
+			<German>Cinder Doorway</German>
+			<Russian>Cinder Doorway</Russian>
+			<Spanish>Cinder Doorway</Spanish>
+			<French>Cinder Doorway</French>
+			<Czech>Cinder Doorway</Czech>
 		</Key>
 		<Key ID="STR_EPOCH_BLOCKDOORWAY_DESC">
 			<English>Cinder block doorway.</English>
@@ -16463,12 +16463,12 @@
 			<Czech>Cinder block doorway.</Czech>
 		</Key>
 		<Key ID="STR_EPOCH_BLOCKGARAGEDOORWAY">
-			<English>Block Garage Doorway</English>
-			<German>Block Garage Doorway</German>
-			<Russian>Block Garage Doorway</Russian>
-			<Spanish>Block Garage Doorway</Spanish>
-			<French>Block Garage Doorway</French>
-			<Czech>Block Garage Doorway</Czech>
+			<English>Cinder Garage Doorway</English>
+			<German>Cinder Garage Doorway</German>
+			<Russian>Cinder Garage Doorway</Russian>
+			<Spanish>Cinder Garage Doorway</Spanish>
+			<French>Cinder Garage Doorway</French>
+			<Czech>Cinder Garage Doorway</Czech>
 		</Key>
 		<Key ID="STR_EPOCH_BLOCKGARAGEDOORWAY_DESC">
 			<English>Cinder block garage doorway.</English>


### PR DESCRIPTION
This makes Block doorways and block garage door ways rename to Cinder doorways and
Cinder garage door ways so they will be alphabetized properly.

It was always annoying having block doorways not near cinder stuff.