### PR TITLE
Advanced trading change to buyables list

### DIFF
--- a/SQF/dayz_code/actions/AdvancedTrading/functions/z_at_fillBuyableList.sqf
+++ b/SQF/dayz_code/actions/AdvancedTrading/functions/z_at_fillBuyableList.sqf
@@ -1,7 +1,28 @@
-private "_index";
+private ["_index","_count","_type","_name","_weapons"];
 #include "defines.hpp"
 
 {
+	_name = _x select 0;
+	_type = _x select 1;
+
+	if (_type == "trade_any_vehicle") then { 
+		_count = { local _x } count (nearestObjects [(getPosATL player), [_name], Z_VehicleDistance]); 
+	};
+	if (_type == "trade_items") then {
+		_count = {_x == _name} count magazines player;
+	};
+	if (_type == "trade_weapons") then {
+		_weapons = weapons player;
+		_weapons set [count _weapons,dayz_onBack];
+		_count = {_x == _name} count _weapons;
+	};
+	if (_type == "trade_backpacks") then { 
+		if (_name == typeOf (unitBackPack player)) then { _count = 1; } 
+	};
+	
 	_index = lbAdd [Z_AT_BUYABLELIST,  _x select 3];
 	lbSetPicture [Z_AT_BUYABLELIST, _index, _x select 4 ];
+	if (_count > 0) then {
+		lbSetColor [Z_AT_BUYABLELIST, _index, [0, 1, 0, 1]];
+	};
 } count Z_BuyableArray;


### PR DESCRIPTION
This changes Advanced trading to change the item color to green if it
matches with an item that is in your inventory, in your weapon slots (main
slot and dayz_onBack) is the same backpack that you are wearing or is a vehicle you are
local to.

This brings it in line with default trader, except we're using local
here since that's all that matters and default trader returns all vehicles (which I never saw the point in)

Thanks to @ebaydayz for the suggestion.