### PR TITLE
Advanced trading buyable list changes

### DIFF
--- a/SQF/dayz_code/actions/AdvancedTrading/functions/z_at_fillBuyableList.sqf
+++ b/SQF/dayz_code/actions/AdvancedTrading/functions/z_at_fillBuyableList.sqf
@@ -1,27 +1,36 @@
-private ["_index","_count","_type","_name","_weapons"];
+private ["_index","_count","_type","_name","_weapons","_typeOf"];
 #include "defines.hpp"
 
+_weapons = weapons player;
+_weapons set [count _weapons,dayz_onBack];
+_typeOf = typeOf (unitBackPack player);
+_count = 0;
+
 {
+	_index = lbAdd [Z_AT_BUYABLELIST,  _x select 3];
+	lbSetPicture [Z_AT_BUYABLELIST, _index, _x select 4 ];
 	_name = _x select 0;
 	_type = _x select 1;
-
-	if (_type == "trade_any_vehicle") then { 
-		_count = { local _x } count (nearestObjects [(getPosATL player), [_name], Z_VehicleDistance]); 
+	
+	if (_type in ["trade_any_vehicle", "trade_any_vehicle_free", "trade_any_vehicle_old", "trade_any_bicycle", "trade_any_bicycle_old", "trade_any_boat", "trade_any_boat_old"]) then {
+		_count = { local _x } count (nearestObjects [(getPosATL player), [_name], Z_VehicleDistance]);
 	};
+
 	if (_type == "trade_items") then {
+		{
+			if (isText(configFile >> "CfgWeapons" >> _x >> "Attachments" >> _name) or _name in getArray (configFile >> "CfgWeapons" >> _x >> "magazines")) then {
+				lbSetColor [Z_AT_BUYABLELIST, _index, [.0,.6,.9,1]];
+			};
+		} count _weapons;
 		_count = {_x == _name} count magazines player;
 	};
 	if (_type == "trade_weapons") then {
-		_weapons = weapons player;
-		_weapons set [count _weapons,dayz_onBack];
 		_count = {_x == _name} count _weapons;
 	};
 	if (_type == "trade_backpacks") then { 
-		if (_name == typeOf (unitBackPack player)) then { _count = 1; } 
+		if (_name == _typeOf) then { _count = 1; }
 	};
 	
-	_index = lbAdd [Z_AT_BUYABLELIST,  _x select 3];
-	lbSetPicture [Z_AT_BUYABLELIST, _index, _x select 4 ];
 	if (_count > 0) then {
 		lbSetColor [Z_AT_BUYABLELIST, _index, [0, 1, 0, 1]];
 	};


### PR DESCRIPTION
Further changes Advanced trading buyable list to show the item as blue
if it's compatible attachment wise and ammo wise.

This will get overwritten if the player has the item in their inventory
by staying green.

Also fixes a small bug I put into my last commit by not showing up for
boats/bikes etc.