### PR TITLE
Advanced trading selling upgraded vehicles.

### DIFF
--- a/SQF/dayz_code/Configs/CfgVehicles/Car/ArmoredSUV.hpp
+++ b/SQF/dayz_code/Configs/CfgVehicles/Car/ArmoredSUV.hpp
@@ -397,6 +397,7 @@ class ArmoredSUV_PMC_DZE: ArmoredSUV_Base_PMC
 
 class ArmoredSUV_PMC_DZE1: ArmoredSUV_PMC_DZE
 {
+	original = "ArmoredSUV_PMC_DZE";
 	maxSpeed = 270; //increased speed slightly since original is 230
 	brakeDistance = 14;
 	terrainCoef = 1.5;

--- a/SQF/dayz_code/Configs/CfgVehicles/Car/CAR_HATCHBACK.hpp
+++ b/SQF/dayz_code/Configs/CfgVehicles/Car/CAR_HATCHBACK.hpp
@@ -13,6 +13,7 @@
 
 // Performance 1
 class car_hatchback_DZE1: car_hatchback {
+	original = "car_hatchback";
 	maxspeed = 150; // max engine limit 125-130
 	terrainCoef = 2.5;
 

--- a/SQF/dayz_code/Configs/CfgVehicles/Car/CAR_SEDAN.hpp
+++ b/SQF/dayz_code/Configs/CfgVehicles/Car/CAR_SEDAN.hpp
@@ -13,6 +13,7 @@ class car_sedan : SkodaBase {
 
 // Performance 1
 class car_sedan_DZE1: car_sedan {
+	original = "car_sedan";
 	maxspeed = 150; // max engine limit 125-130
 	terrainCoef = 2.5;
 

--- a/SQF/dayz_code/Configs/CfgVehicles/Car/Kamaz.hpp
+++ b/SQF/dayz_code/Configs/CfgVehicles/Car/Kamaz.hpp
@@ -25,6 +25,7 @@ class Kamaz_DZE: Kamaz_Base {
 	};
 };
 class KamazOpen_DZE1: KamazOpen_DZE {
+	original = "KamazOpen_DZE";
 	maxspeed = 100; //base 80
 	terrainCoef = 1.8;  // base 2.0
 	turnCoef = 2.0;  // base 3.7
@@ -33,6 +34,7 @@ class KamazOpen_DZE1: KamazOpen_DZE {
 	};
 };
 class Kamaz_DZE1: Kamaz_DZE {
+	original = "Kamaz_DZE";
 	maxspeed = 100; //base 80
 	terrainCoef = 1.8;  // base 2.0
 	turnCoef = 2.0;  // base 3.7
@@ -89,6 +91,7 @@ class KamazRefuel_DZ: KamazRefuel {
 	//For future Developement = transportFuel = 10400;			// refueltruck
 };
 class KamazRefuel_DZE1: KamazRefuel_DZ {
+	original = "KamazRefuel_DZ";
 	maxspeed = 100; //base 80
 	terrainCoef = 1.8;  // base 2.0
 	turnCoef = 2.0;  // base 3.7

--- a/SQF/dayz_code/Configs/CfgVehicles/Car/Lada.hpp
+++ b/SQF/dayz_code/Configs/CfgVehicles/Car/Lada.hpp
@@ -460,6 +460,7 @@ class Lada2_TK_CIV_EP1: Lada_base {
 
 // Performance 1
 class Lada1_DZE1: Lada1 {
+	original = "Lada1";
 	maxspeed = 150; // max engine limit 125-130
 	terrainCoef = 2.5;
 
@@ -468,6 +469,7 @@ class Lada1_DZE1: Lada1 {
 	};
 };
 class Lada2_DZE1: Lada2 {
+	original = "Lada2";
 	maxspeed = 150; // car 100
 	terrainCoef = 2.5;
 
@@ -476,6 +478,7 @@ class Lada2_DZE1: Lada2 {
 	};
 };
 class LadaLM_DZE1: LadaLM {
+	original = "LadaLM";
 	maxspeed = 150; // car 100
 	terrainCoef = 2.5;
 
@@ -484,6 +487,7 @@ class LadaLM_DZE1: LadaLM {
 	};
 };
 class Lada1_TK_CIV_EP1_DZE1: Lada1_TK_CIV_EP1 {
+	original = "Lada1_TK_CIV_EP1";
 	maxspeed = 150; // car 100
 	terrainCoef = 2.5;
 
@@ -492,6 +496,7 @@ class Lada1_TK_CIV_EP1_DZE1: Lada1_TK_CIV_EP1 {
 	};
 };
 class Lada2_TK_CIV_EP1_DZE1: Lada2_TK_CIV_EP1 {
+	original = "Lada2_TK_CIV_EP1";
 	maxspeed = 150; // car 100
 	terrainCoef = 2.5;
 

--- a/SQF/dayz_code/Configs/CfgVehicles/Car/Offroad_DSHKM_INS.hpp
+++ b/SQF/dayz_code/Configs/CfgVehicles/Car/Offroad_DSHKM_INS.hpp
@@ -346,6 +346,7 @@ class Offroad_DSHKM_Gue_DZE: Offroad_DSHKM_base
 // Performance 1
 class Offroad_DSHKM_Gue_DZE1: Offroad_DSHKM_Gue_DZE
 {
+	original = "Offroad_DSHKM_Gue_DZE";
 	maxspeed = 170; // Offroad_DSHKM_base 150 | car 100
 	class Upgrades
 	{

--- a/SQF/dayz_code/Configs/CfgVehicles/Car/Pickup_PK_INS.hpp
+++ b/SQF/dayz_code/Configs/CfgVehicles/Car/Pickup_PK_INS.hpp
@@ -120,6 +120,7 @@ class Pickup_PK_INS_DZE: Pickup_PK_INS_DZ {
 
 // Performance 1
 class Pickup_PK_GUE_DZE1: Pickup_PK_GUE_DZE {
+	original = "Pickup_PK_GUE_DZE";
 	maxspeed = 150; // max engine limit 125-130
 	terrainCoef = 1.8;
 
@@ -128,6 +129,7 @@ class Pickup_PK_GUE_DZE1: Pickup_PK_GUE_DZE {
 	};
 };
 class Pickup_PK_TK_GUE_EP1_DZE1: Pickup_PK_TK_GUE_EP1_DZE {
+	original = "Pickup_PK_TK_GUE_EP1_DZE";
 	maxspeed = 150; // max engine limit 125-130
 	terrainCoef = 1.8;
 
@@ -136,6 +138,7 @@ class Pickup_PK_TK_GUE_EP1_DZE1: Pickup_PK_TK_GUE_EP1_DZE {
 	};
 };
 class Pickup_PK_INS_DZE1: Pickup_PK_INS_DZE {
+	original = "Pickup_PK_INS_DZE";
 	maxspeed = 150; // max engine limit 125-130
 	terrainCoef = 1.8;
 

--- a/SQF/dayz_code/Configs/CfgVehicles/Car/SUV_DZ.hpp
+++ b/SQF/dayz_code/Configs/CfgVehicles/Car/SUV_DZ.hpp
@@ -177,6 +177,7 @@ class SUV_Silver: SUV_TK_CIV_EP1 {
 
 // Performance 1
 class SUV_TK_CIV_EP1_DZE1: SUV_TK_CIV_EP1 {
+	original = "SUV_TK_CIV_EP1";
 	maxSpeed = 250; // max engine limit 125-130
 	brakeDistance = 14; // 19
 	terrainCoef = 1.5;
@@ -186,6 +187,7 @@ class SUV_TK_CIV_EP1_DZE1: SUV_TK_CIV_EP1 {
 	};
 };
 class SUV_Camo_DZE1: SUV_Camo {
+	original = "SUV_Camo";
 	maxSpeed = 250; // max engine limit 125-130
 	brakeDistance = 14; // 19
 	terrainCoef = 1.5;
@@ -195,6 +197,7 @@ class SUV_Camo_DZE1: SUV_Camo {
 	};
 };
 class SUV_Blue_DZE1: SUV_Blue {
+	original = "SUV_Blue";
 	maxSpeed = 250; // suv base 130
 	terrainCoef = 1.5;
 	brakeDistance = 14; // 19
@@ -204,6 +207,7 @@ class SUV_Blue_DZE1: SUV_Blue {
 	};
 };
 class SUV_Green_DZE1: SUV_Green {
+	original = "SUV_Green";
 	maxSpeed = 250; // suv base 130
 	terrainCoef = 1.5;
 	brakeDistance = 14; // 19
@@ -213,6 +217,7 @@ class SUV_Green_DZE1: SUV_Green {
 	};
 };
 class SUV_Yellow_DZE1: SUV_Yellow {
+	original = "SUV_Yellow";
 	maxSpeed = 250; // max engine limit 125-130
 	terrainCoef = 1.5;
 	brakeDistance = 14; // 19
@@ -222,6 +227,7 @@ class SUV_Yellow_DZE1: SUV_Yellow {
 	};
 };
 class SUV_Red_DZE1: SUV_Red {
+	original = "SUV_Red";
 	maxSpeed = 250; // suv base 130
 	terrainCoef = 1.5;
 	brakeDistance = 14; // 19
@@ -231,6 +237,7 @@ class SUV_Red_DZE1: SUV_Red {
 	};
 };
 class SUV_White_DZE1: SUV_White {
+	original = "SUV_White";
 	maxSpeed = 250; // suv base 130
 	terrainCoef = 1.5;
 	brakeDistance = 14; // 19
@@ -240,6 +247,7 @@ class SUV_White_DZE1: SUV_White {
 	};
 };
 class SUV_Pink_DZE1: SUV_Pink {
+	original = "SUV_Pink";
 	maxSpeed = 250; // suv base 130
 	terrainCoef = 1.5;
 	brakeDistance = 14; // 19
@@ -249,6 +257,7 @@ class SUV_Pink_DZE1: SUV_Pink {
 	};
 };
 class SUV_Charcoal_DZE1: SUV_Charcoal {
+	original = "SUV_Charcoal";
 	maxSpeed = 250; // max engine limit 125-130
 	terrainCoef = 1.5;
 	brakeDistance = 14; // 19
@@ -258,6 +267,7 @@ class SUV_Charcoal_DZE1: SUV_Charcoal {
 	};
 };
 class SUV_Orange_DZE1: SUV_Orange {
+	original = "SUV_Orange";
 	maxSpeed = 250; // suv base 130
 	terrainCoef = 1.5;
 	brakeDistance = 14; // 19
@@ -267,6 +277,7 @@ class SUV_Orange_DZE1: SUV_Orange {
 	};
 };
 class SUV_Silver_DZE1: SUV_Silver {
+	original = "SUV_Silver";
 	maxSpeed = 250; // suv base 130
 	terrainCoef = 1.5;
 	brakeDistance = 14; // 19

--- a/SQF/dayz_code/Configs/CfgVehicles/Car/Skoda.hpp
+++ b/SQF/dayz_code/Configs/CfgVehicles/Car/Skoda.hpp
@@ -101,6 +101,7 @@ class SkodaGreen: SkodaBase {
 
 // Performance 1
 class Skoda_DZE1: Skoda {
+	original = "Skoda";
 	maxspeed = 150; // max engine limit 125-130
 	terrainCoef = 2.5;
 
@@ -109,6 +110,7 @@ class Skoda_DZE1: Skoda {
 	};
 };
 class SkodaBlue_DZE1: SkodaBlue {
+	original = "SkodaBlue";
 	maxspeed = 150; // car 100
 	terrainCoef = 2.5;
 
@@ -117,6 +119,7 @@ class SkodaBlue_DZE1: SkodaBlue {
 	};
 };
 class SkodaRed_DZE1: SkodaRed {
+	original = "SkodaRed";
 	maxspeed = 150; // car 100
 	terrainCoef = 2.5;
 
@@ -125,6 +128,7 @@ class SkodaRed_DZE1: SkodaRed {
 	};
 };
 class SkodaGreen_DZE1: SkodaGreen {
+	original = "SkodaGreen";
 	maxspeed = 150; // car 100
 	terrainCoef = 2.5;
 

--- a/SQF/dayz_code/Configs/CfgVehicles/Car/UAZ.hpp
+++ b/SQF/dayz_code/Configs/CfgVehicles/Car/UAZ.hpp
@@ -175,6 +175,7 @@ class UAZ_Unarmed_TK_CIV_EP1: UAZ_Unarmed_Base {
 
 // Performance 1
 class UAZ_CDF_DZE1: UAZ_CDF {
+	original = "UAZ_CDF";
 	maxspeed = 240; // max engine limit 125-130
 	terrainCoef = 2.5;
 
@@ -183,6 +184,7 @@ class UAZ_CDF_DZE1: UAZ_CDF {
 	};
 };
 class UAZ_INS_DZE1: UAZ_INS {
+	original = "UAZ_INS";
 	maxspeed = 240; // car 100
 	terrainCoef = 2.5;
 
@@ -191,6 +193,7 @@ class UAZ_INS_DZE1: UAZ_INS {
 	};
 };
 class UAZ_RU_DZE1: UAZ_RU {
+	original = "UAZ_RU";
 	maxspeed = 240; // car 100
 	terrainCoef = 2.5;
 
@@ -199,6 +202,7 @@ class UAZ_RU_DZE1: UAZ_RU {
 	};
 };
 class UAZ_Unarmed_TK_EP1_DZE1: UAZ_Unarmed_TK_EP1 {
+	original = "UAZ_Unarmed_TK_EP1";
 	maxspeed = 240; // max engine limit 125-130
 	terrainCoef = 2.5;
 
@@ -207,6 +211,7 @@ class UAZ_Unarmed_TK_EP1_DZE1: UAZ_Unarmed_TK_EP1 {
 	};
 };
 class UAZ_Unarmed_UN_EP1_DZE1: UAZ_Unarmed_UN_EP1 {
+	original = "UAZ_Unarmed_UN_EP1";
 	maxspeed = 240; // car 100
 	terrainCoef = 2.5;
 
@@ -215,6 +220,7 @@ class UAZ_Unarmed_UN_EP1_DZE1: UAZ_Unarmed_UN_EP1 {
 	};
 };
 class UAZ_Unarmed_TK_CIV_EP1_DZE1: UAZ_Unarmed_TK_CIV_EP1 {
+	original = "UAZ_Unarmed_TK_CIV_EP1";
 	maxspeed = 240; // car 100
 	terrainCoef = 2.5;
 

--- a/SQF/dayz_code/Configs/CfgVehicles/Car/VWGolf.hpp
+++ b/SQF/dayz_code/Configs/CfgVehicles/Car/VWGolf.hpp
@@ -494,6 +494,7 @@ class VWGolf : Car {
 
 // Performance 1
 class VWGolf_DZE1: VWGolf {
+	original = "VWGolf";
 	maxSpeed = 260; // VW maxspeed from above =241
 	terrainCoef = 2.5;
 

--- a/SQF/dayz_code/Configs/CfgVehicles/Car/Volha.hpp
+++ b/SQF/dayz_code/Configs/CfgVehicles/Car/Volha.hpp
@@ -254,6 +254,7 @@ class VolhaLimo_TK_CIV_EP1: Volha_TK_CIV_Base_EP1 {
 
 // Performance 1
 class VolhaLimo_TK_CIV_EP1_DZE1: VolhaLimo_TK_CIV_EP1 {
+	original = "VolhaLimo_TK_CIV_EP1";
 	maxspeed = 150; // max engine limit 125-130
 	terrainCoef = 2.5;
 
@@ -262,6 +263,7 @@ class VolhaLimo_TK_CIV_EP1_DZE1: VolhaLimo_TK_CIV_EP1 {
 	};
 };
 class Volha_1_TK_CIV_EP1_DZE1: Volha_1_TK_CIV_EP1 {
+	original = "Volha_1_TK_CIV_EP1";
 	maxspeed = 150; // car 100
 	terrainCoef = 2.5;
 
@@ -270,6 +272,7 @@ class Volha_1_TK_CIV_EP1_DZE1: Volha_1_TK_CIV_EP1 {
 	};
 };
 class Volha_2_TK_CIV_EP1_DZE1: Volha_2_TK_CIV_EP1 {
+	original = "Volha_2_TK_CIV_EP1";
 	maxspeed = 150; // car 100
 	terrainCoef = 2.5;
 

--- a/SQF/dayz_code/Configs/CfgVehicles/Car/datsun.hpp
+++ b/SQF/dayz_code/Configs/CfgVehicles/Car/datsun.hpp
@@ -31,6 +31,7 @@ class datsun1_civil_3_open_DZE: datsun1_civil_3_open {
 
 // Performance 1
 class datsun1_civil_1_open_DZE1: datsun1_civil_1_open_DZE {
+	original = "datsun1_civil_1_open_DZE";
 	maxspeed = 150; // max engine limit 125-130
 	terrainCoef = 1.8;
 	class HitPoints: HitPoints {
@@ -52,6 +53,7 @@ class datsun1_civil_1_open_DZE1: datsun1_civil_1_open_DZE {
 	};
 };
 class datsun1_civil_2_covered_DZE1: datsun1_civil_2_covered_DZE {
+	original = "datsun1_civil_2_covered_DZE";
 	maxspeed = 150; // car 100
 	terrainCoef = 1.8;
 	class HitPoints: HitPoints {
@@ -73,6 +75,7 @@ class datsun1_civil_2_covered_DZE1: datsun1_civil_2_covered_DZE {
 	};
 };
 class datsun1_civil_3_open_DZE1: datsun1_civil_3_open_DZE {
+	original = "datsun1_civil_3_open_DZE";
 	maxspeed = 150; // car 100
 	terrainCoef = 1.8;
 	class HitPoints: HitPoints {

--- a/SQF/dayz_code/Configs/CfgVehicles/Car/hilux.hpp
+++ b/SQF/dayz_code/Configs/CfgVehicles/Car/hilux.hpp
@@ -31,6 +31,7 @@ class hilux1_civil_3_open_DZE: hilux1_civil_3_open {
 
 // Performance 1
 class hilux1_civil_1_open_DZE1: hilux1_civil_1_open_DZE {
+	original = "hilux1_civil_1_open_DZE";
 	maxspeed = 150; // max engine limit 125-130
 	terrainCoef = 1.8;
 	class HitPoints: HitPoints {
@@ -52,6 +53,7 @@ class hilux1_civil_1_open_DZE1: hilux1_civil_1_open_DZE {
 	};
 };
 class hilux1_civil_2_covered_DZE1: hilux1_civil_2_covered_DZE {
+	original = "hilux1_civil_2_covered_DZE";
 	maxspeed = 150; // car 100
 	terrainCoef = 1.8;
 	class HitPoints: HitPoints {
@@ -73,6 +75,7 @@ class hilux1_civil_2_covered_DZE1: hilux1_civil_2_covered_DZE {
 	};
 };
 class hilux1_civil_3_open_DZE1: hilux1_civil_3_open_DZE {
+	original = "hilux1_civil_3_open_DZE";
 	maxspeed = 150; // car 100
 	terrainCoef = 1.8;
 	class HitPoints: HitPoints {

--- a/SQF/dayz_code/actions/AdvancedTrading/functions/z_at_checkArrayInConfig.sqf
+++ b/SQF/dayz_code/actions/AdvancedTrading/functions/z_at_checkArrayInConfig.sqf
@@ -8,7 +8,7 @@
 *
 *	Fills up the sell or buy list if the item has a valid config.
 **/
-private ["_weaps","_mags","_extraText","_all","_arrayOfTraderCat","_totalPrice","_backUpText","_bags"];
+private ["_weaps","_mags","_extraText","_all","_arrayOfTraderCat","_totalPrice","_backUpText","_bags","_vehUpgraded"];
 #include "defines.hpp"
 
 _weaps = _this select 0;
@@ -18,6 +18,7 @@ _bags = _this select 3;
 _vehTrade = false;
 
 if (false call Z_checkCloseVehicle) then {
+	_vehUpgraded = getText (configFile >> 'CfgVehicles' >> typeOf (Z_vehicle) >> 'original');
 	_all = _weaps + _mags + _bags + [(typeOf Z_vehicle)];
 	_vehTrade = true;
 } else {
@@ -54,6 +55,7 @@ _totalPrice = 0;
 		if (isNumber (missionConfigFile >> "CfgTraderCategory" >> _cat >> "duplicate")) then {
 			_cat = format["Category_%1",getNumber (missionConfigFile >> "CfgTraderCategory" >> _cat >> "duplicate")];
 		};
+		if (_vehUpgraded != "" && _vehTrade && _y == (typeOf Z_vehicle)) then { _y = _vehUpgraded; };
 		_exists = isClass(missionConfigFile >> "CfgTraderCategory"  >> _cat >> _y);
 		if (_exists) exitWith {
 			_pic = "";


### PR DESCRIPTION
These changes allow the player to sell upgraded vehicles with them not
needing to be added to the trader (as to not pollute the lists). This basically
refers to an upgraded vehicle as a child of the base vehicle so it will
get the same sell price as the base vehicle.

This still follows the original trading convention, the vehicle base
needs to be in the trader category, i.e you cant sell an armored SUV at
stary vehicle trader.