### PR TITLE
Adding many new vehicles to configs

### DIFF
--- a/CHANGE LOG 1.0.6.txt
+++ b/CHANGE LOG 1.0.6.txt
@@ -44,6 +44,7 @@
 [NEW] More possible causes of death added to study body: fell, ran over, shot, melee hit, zombie hit @ebaydayz
 [NEW] Player-list no longer shows who's in lobby or ingame.
 [NEW] 35 new male clothing classes added. #1732 #1734 @AirWavesMan
+[NEW] Added new BRDM2, AN2, HMMWV, Mi17 and Cessna _DZ classes with radar disabled. #1746 @AirWavesMan
 [NEW] Added SCAR Mk16 and Mk17 variants, L86 and AA12 to loot tables and traders. #1743 @AirWavesMan
 
 [CHANGED] Combattimeout now uses diag_tickTime instead of time.

--- a/SQF/dayz_code/Configs/CfgServerTrader/Category/NeutralAirplanes.hpp
+++ b/SQF/dayz_code/Configs/CfgServerTrader/Category/NeutralAirplanes.hpp
@@ -1,20 +1,20 @@
 class Category_517 {
-	class GNT_C185U {
+	class GNT_C185U_DZ {
 		type = "trade_any_vehicle";
 		buy[] = {4,"ItemGoldBar10oz"};
 		sell[] = {2,"ItemGoldBar10oz"};
 	};
-	class GNT_C185 {
+	class GNT_C185_DZ {
 		type = "trade_any_vehicle";
 		buy[] = {4,"ItemGoldBar10oz"};
 		sell[] = {2,"ItemGoldBar10oz"};
 	};
-	class GNT_C185R {
+	class GNT_C185R_DZ {
 		type = "trade_any_vehicle";
 		buy[] = {4,"ItemGoldBar10oz"};
 		sell[] = {2,"ItemGoldBar10oz"};
 	};
-	class GNT_C185C {
+	class GNT_C185C_DZ {
 		type = "trade_any_vehicle";
 		buy[] = {4,"ItemGoldBar10oz"};
 		sell[] = {2,"ItemGoldBar10oz"};

--- a/SQF/dayz_code/Configs/CfgVehicles/Car/BRDM2_DZ.hpp
+++ b/SQF/dayz_code/Configs/CfgVehicles/Car/BRDM2_DZ.hpp
@@ -1,0 +1,12 @@
+class BRDM2_HQ_TK_GUE_EP1;
+class BRDM2_HQ_TK_GUE_EP1_DZ: BRDM2_HQ_TK_GUE_EP1 {
+	scope = public;
+	displayname = "BRDM2 (PKT)";
+	displaynameshort = "BRDM2 (PKT)";
+	armor = 85;
+	damageResistance = 0.032;
+	commanderCanSee = 2+16+32;
+	gunnerCanSee = 2+16+32;
+	driverCanSee = 2+16+32;
+	fuelCapacity = 220;
+};

--- a/SQF/dayz_code/Configs/CfgVehicles/Car/BRDM2_DZ.hpp
+++ b/SQF/dayz_code/Configs/CfgVehicles/Car/BRDM2_DZ.hpp
@@ -3,6 +3,10 @@ class BRDM2_HQ_TK_GUE_EP1_DZ: BRDM2_HQ_TK_GUE_EP1 {
 	scope = public;
 	displayname = "BRDM2 (PKT)";
 	displaynameshort = "BRDM2 (PKT)";
+	crew = "";
+	typicalCargo[] = {};
+	class TransportMagazines {};
+	class TransportWeapons {};
 	armor = 85;
 	damageResistance = 0.032;
 	commanderCanSee = 2+16+32;

--- a/SQF/dayz_code/Configs/CfgVehicles/Car/HMMWV.hpp
+++ b/SQF/dayz_code/Configs/CfgVehicles/Car/HMMWV.hpp
@@ -306,9 +306,11 @@ class HMMWV_Base: Car
 };
 
 class HMMWV_DZ: HMMWV_Base {
+	
 	accuracy = 0.32;
 	displayname = $STR_VEH_NAME_HMMWV;
-	maxspeed = 230;
+	displaynameshort = "HMMWV (Wood Camo)";
+	maxspeed = 100;
 	hasgunner = 0;
 	hiddenselections[] = {"Camo1"};
 	hiddenselectionstextures[] = {"\ca\wheeled\hmmwv\data\hmmwv_body_co.paa"};
@@ -322,7 +324,7 @@ class HMMWV_DZ: HMMWV_Base {
 	typicalCargo[] = {};
 	transportMaxWeapons = 10;
 	transportMaxMagazines = 50;
-	transportmaxbackpacks = 2;
+	transportmaxbackpacks = 4;
 	class Turrets {};
 	class Damage {
 		mat[] = {"ca\wheeled\hmmwv\data\hmmwv_details.rvmat", "Ca\wheeled\HMMWV\data\hmmwv_details_damage.rvmat", "Ca\wheeled\HMMWV\data\hmmwv_details_destruct.rvmat", "ca\wheeled\hmmwv\data\hmmwv_body.rvmat", "Ca\wheeled\HMMWV\data\hmmwv_body_damage.rvmat", "Ca\wheeled\HMMWV\data\hmmwv_body_destruct.rvmat", "ca\wheeled\hmmwv\data\hmmwv_clocks.rvmat", "ca\wheeled\hmmwv\data\hmmwv_clocks.rvmat", "ca\wheeled\data\hmmwv_clocks_destruct.rvmat", "ca\wheeled\HMMWV\data\hmmwv_glass.rvmat", "ca\wheeled\HMMWV\data\hmmwv_glass_Half_D.rvmat", "ca\wheeled\HMMWV\data\hmmwv_glass_Half_D.rvmat", "ca\wheeled\HMMWV\data\hmmwv_glass_in.rvmat", "ca\wheeled\HMMWV\data\hmmwv_glass_in_Half_D.rvmat", "ca\wheeled\HMMWV\data\hmmwv_glass_in_Half_D.rvmat"};
@@ -1078,4 +1080,28 @@ class HMMWV_M1151_M2_CZ_DES_EP1_DZE: HMMWV_M1151_M2_DES_Base_EP1_DZE
 		tex[] = {};
 		mat[] = {"Ca\wheeled_E\HMMWV\data\hmmwv_body_1.rvmat","Ca\wheeled_E\HMMWV\data\hmmwv_body_1_damage.rvmat","Ca\wheeled_E\HMMWV\data\hmmwv_body_1_destruct.rvmat","Ca\wheeled_E\HMMWV\data\hmmwv_hood.rvmat","Ca\wheeled_E\HMMWV\data\hmmwv_hood_damage.rvmat","Ca\wheeled_E\HMMWV\data\hmmwv_hood_destruct.rvmat","Ca\wheeled_E\HMMWV\data\hmmwv_parts_1.rvmat","Ca\wheeled_E\HMMWV\data\hmmwv_parts_1_damage.rvmat","Ca\wheeled_E\HMMWV\data\hmmwv_parts_1_destruct.rvmat","Ca\wheeled_E\HMMWV\data\hmmwv_regular_1.rvmat","Ca\wheeled_E\HMMWV\data\hmmwv_regular_1_damage.rvmat","Ca\wheeled_E\HMMWV\data\hmmwv_regular_1_destruct.rvmat","Ca\wheeled_E\HMMWV\Data\hmmwv_gpk_tower.rvmat","Ca\wheeled_E\HMMWV\Data\hmmwv_gpk_tower_damage.rvmat","Ca\wheeled_E\HMMWV\Data\hmmwv_gpk_tower_destruct.rvmat","Ca\Ca_E\data\default.rvmat","Ca\Ca_E\data\default.rvmat","Ca\Ca_E\data\default_destruct.rvmat"};
 	};
+};
+
+class HMMWV_Armored;
+class HMMWV_Armored_DZ: HMMWV_Armored {
+	scope = public;
+	displayname = "HMMWV (M240) Woodland";
+	maxspeed = 100;
+	transportMaxWeapons = 4;
+	transportMaxMagazines = 100;
+	transportmaxbackpacks = 4;
+	armor = 80;
+	damageResistance = 0.00581;
+};
+
+class HMMWV_M2;
+class HMMWV_M2_DZ: HMMWV_M2 {
+	scope = public;
+	displayname = "HMMWV (M2) Woodland";
+	maxspeed = 100;
+	transportMaxWeapons = 4;
+	transportMaxMagazines = 100;
+	transportmaxbackpacks = 4;
+	armor = 80;
+	damageResistance = 0.00581;
 };

--- a/SQF/dayz_code/Configs/CfgVehicles/Car/HMMWV.hpp
+++ b/SQF/dayz_code/Configs/CfgVehicles/Car/HMMWV.hpp
@@ -1087,12 +1087,13 @@ class HMMWV_Armored_DZ: HMMWV_Armored {
 	crew = "";
 	typicalCargo[] = {};
 	class TransportMagazines {};
+	class TransportWeapons {};
 	displayname = "HMMWV (M240) Woodland";
-	transportMaxWeapons = 10;
-	transportMaxMagazines = 50;
+	transportMaxWeapons = 4;
+	transportMaxMagazines = 120;
 	transportmaxbackpacks = 4;
-	armor = 120;
-	damageResistance = 0.00581;
+	armor = 80;
+	damageResistance = 0.03099;
 };
 
 class HMMWV_M2;
@@ -1101,9 +1102,10 @@ class HMMWV_M2_DZ: HMMWV_M2 {
 	crew = "";
 	typicalCargo[] = {};
 	class TransportMagazines {};
+	class TransportWeapons {};
 	displayname = "HMMWV (M2) Woodland";
-	transportMaxWeapons = 10;
-	transportMaxMagazines = 50;
+	transportMaxWeapons = 4;
+	transportMaxMagazines = 120;
 	transportmaxbackpacks = 4;
 	armor = 40;
 	damageResistance = 0.00581;

--- a/SQF/dayz_code/Configs/CfgVehicles/Car/HMMWV.hpp
+++ b/SQF/dayz_code/Configs/CfgVehicles/Car/HMMWV.hpp
@@ -1090,7 +1090,7 @@ class HMMWV_Armored_DZ: HMMWV_Armored {
 	displayname = "HMMWV (M240) Woodland";
 	transportMaxWeapons = 10;
 	transportMaxMagazines = 50;
-	transportmaxbackpacks = 2;
+	transportmaxbackpacks = 4;
 	armor = 120;
 	damageResistance = 0.00581;
 };
@@ -1104,7 +1104,7 @@ class HMMWV_M2_DZ: HMMWV_M2 {
 	displayname = "HMMWV (M2) Woodland";
 	transportMaxWeapons = 10;
 	transportMaxMagazines = 50;
-	transportmaxbackpacks = 2;
+	transportmaxbackpacks = 4;
 	armor = 40;
 	damageResistance = 0.00581;
 };

--- a/SQF/dayz_code/Configs/CfgVehicles/Car/HMMWV.hpp
+++ b/SQF/dayz_code/Configs/CfgVehicles/Car/HMMWV.hpp
@@ -310,7 +310,6 @@ class HMMWV_DZ: HMMWV_Base {
 	accuracy = 0.32;
 	displayname = $STR_VEH_NAME_HMMWV;
 	displaynameshort = "HMMWV (Wood Camo)";
-	maxspeed = 100;
 	hasgunner = 0;
 	hiddenselections[] = {"Camo1"};
 	hiddenselectionstextures[] = {"\ca\wheeled\hmmwv\data\hmmwv_body_co.paa"};
@@ -1085,23 +1084,27 @@ class HMMWV_M1151_M2_CZ_DES_EP1_DZE: HMMWV_M1151_M2_DES_Base_EP1_DZE
 class HMMWV_Armored;
 class HMMWV_Armored_DZ: HMMWV_Armored {
 	scope = public;
+	crew = "";
+	typicalCargo[] = {};
+	class TransportMagazines {};
 	displayname = "HMMWV (M240) Woodland";
-	maxspeed = 100;
-	transportMaxWeapons = 4;
-	transportMaxMagazines = 100;
-	transportmaxbackpacks = 4;
-	armor = 80;
+	transportMaxWeapons = 10;
+	transportMaxMagazines = 50;
+	transportmaxbackpacks = 2;
+	armor = 120;
 	damageResistance = 0.00581;
 };
 
 class HMMWV_M2;
 class HMMWV_M2_DZ: HMMWV_M2 {
 	scope = public;
+	crew = "";
+	typicalCargo[] = {};
+	class TransportMagazines {};
 	displayname = "HMMWV (M2) Woodland";
-	maxspeed = 100;
-	transportMaxWeapons = 4;
-	transportMaxMagazines = 100;
-	transportmaxbackpacks = 4;
-	armor = 80;
+	transportMaxWeapons = 10;
+	transportMaxMagazines = 50;
+	transportmaxbackpacks = 2;
+	armor = 40;
 	damageResistance = 0.00581;
 };

--- a/SQF/dayz_code/Configs/CfgVehicles/CfgVehicles.hpp
+++ b/SQF/dayz_code/Configs/CfgVehicles/CfgVehicles.hpp
@@ -473,6 +473,7 @@ class CfgVehicles {
 	#include "Car\Pickup_PK_INS.hpp"
 	#include "Car\Offroad_DSHKM_INS.hpp"
 	#include "Car\UralCivil_DZ.hpp"
+	#include "Car\BRDM2_DZ.hpp"
 	//Helicopter's
 	#include "Helicopter\MI17.hpp"
 	#include "Helicopter\UH1H.hpp"

--- a/SQF/dayz_code/Configs/CfgVehicles/CfgVehicles.hpp
+++ b/SQF/dayz_code/Configs/CfgVehicles/CfgVehicles.hpp
@@ -493,6 +493,7 @@ class CfgVehicles {
 	#include "Plane\AN2_DZ.hpp"
 	#include "Plane\MV22.hpp"
 	#include "Plane\C130.hpp"
+	#include "Plane\Cessna_DZ.hpp"
 	//Bikes
 	#include "Bikes\ATV_US_EP1.hpp"
 	#include "Bikes\ATV_CZ_EP1.hpp"

--- a/SQF/dayz_code/Configs/CfgVehicles/Helicopter/MI17.hpp
+++ b/SQF/dayz_code/Configs/CfgVehicles/Helicopter/MI17.hpp
@@ -49,8 +49,7 @@ class Mi17_DZE: Mi17_DZ	 {
 	};
 };
 
-class Mi17_TK_EP1: Mi17_base  {};
-class Mi17_TK_EP1_DZ: Mi17_TK_EP1  {
+class Mi17_TK_EP1_DZ: Mi17_base  {
 	displayname = "Mi17_TK_DZ";
 	displaynameshort = "Mi17_TK_DZ";
 	scope = public;
@@ -66,6 +65,7 @@ class Mi17_TK_EP1_DZ: Mi17_TK_EP1  {
 	transportMaxMagazines = 50;
 	transportmaxbackpacks = 10;
 	fuelCapacity = 1870;
+	hiddenSelectionsTextures[] = {"\ca\air_E\Data\mi17_body_IND_CO.paa", "\ca\air_E\Data\mi17_det_IND_CO.paa", "\ca\air\data\clear_empty.paa", "\ca\air\data\mi8_decals_ca.paa"};
 
 	class Turrets : Turrets  {
 		class MainTurret : MainTurret  {
@@ -88,8 +88,7 @@ class Mi17_TK_EP1_DZE: Mi17_TK_EP1_DZ	 {
 	};
 };
 
-class Mi17_UN_CDF_EP1: Mi17_base  {};
-class Mi17_UN_CDF_EP1_DZ: Mi17_UN_CDF_EP1  {
+class Mi17_UN_CDF_EP1_DZ: Mi17_base  {
 	displayname = "Mi17_UN_CDF_EP1_DZ";
 	displaynameshort = "Mi17_UN_CDF_EP1_DZ";
 	scope = public;
@@ -105,6 +104,7 @@ class Mi17_UN_CDF_EP1_DZ: Mi17_UN_CDF_EP1  {
 	transportMaxMagazines = 50;
 	transportmaxbackpacks = 10;
 	fuelCapacity = 1870;
+	hiddenSelectionsTextures[] = {"\CA\air_E\data\mi17_body_UN_CO.paa", "\CA\air_E\data\mi17_det_UN_CO.paa", "\ca\air_E\Data\mi17_decals2_UN_CA.paa", "\ca\air_E\Data\mi17_decals_UN_CA.paa"};
 
 	class Turrets : Turrets  {
 		class MainTurret : MainTurret  {
@@ -115,7 +115,6 @@ class Mi17_UN_CDF_EP1_DZ: Mi17_UN_CDF_EP1  {
 		};
 	};
 };
-
 class Mi17_UN_CDF_EP1_DZE: Mi17_UN_CDF_EP1_DZ	 {
 	displaynameshort = "Mi17_UN_CDF_EP1_DZE";
 	class Turrets : Turrets  {
@@ -128,8 +127,7 @@ class Mi17_UN_CDF_EP1_DZE: Mi17_UN_CDF_EP1_DZ	 {
 	};
 };
 
-class Mi17_CDF: Mi17_base  {};
-class Mi17_CDF_DZ: Mi17_CDF  {
+class Mi17_CDF_DZ: Mi17_base {
 	displayname = "Mi17_CDF_DZ";
 	displaynameshort = "Mi17_CDF_DZ";
 	scope = public;
@@ -145,6 +143,7 @@ class Mi17_CDF_DZ: Mi17_CDF  {
 	transportMaxMagazines = 50;
 	transportmaxbackpacks = 10;
 	fuelCapacity = 1870;
+	hiddenSelectionsTextures[] = {"\CA\air\data\mi8_body_g_CDF_CO.paa", "ca\air\data\mi8_det_g_co.paa", "ca\air\data\clear_empty.paa", "ca\air\data\mi8_decals_ca.paa"};
 
 	class Turrets : Turrets  {
 		class MainTurret : MainTurret  {
@@ -163,6 +162,161 @@ class Mi17_CDF_DZE: Mi17_CDF_DZ	 {
 		};
 		class BackTurret : BackTurret {
 			magazines[] = {};
+		};
+	};
+};
+
+class Mi171Sh_CZ_EP1_DZ: Mi17_base {
+	displayname = "Mi171Sh_CZ_EP1_DZ";
+	displaynameshort = "Mi171Sh_CZ_EP1_DZ";
+	scope = public;
+	side = 2;
+	crew = "";
+	typicalCargo[] = {};
+	class TransportMagazines{};
+	class TransportWeapons{};
+	commanderCanSee = 2+16+32;
+	gunnerCanSee = 2+16+32;
+	driverCanSee = 2+16+32;
+	transportMaxWeapons = 10;
+	transportMaxMagazines = 50;
+	transportmaxbackpacks = 10;
+	fuelCapacity = 1870;
+	hiddenSelectionsTextures[] = {"\CA\air_E\data\mi17_body_ACR_CO.paa", "\CA\air_E\data\mi17_det_ACR_CO.paa", "\ca\air_E\Data\mi17_decals2_ACR_CA.paa", "\ca\air\data\mi8_decals_ca.paa"};
+	
+	model = "\ca\Air_E\Mi17\Mi_171";
+	picture = "\ca\air\data\ico\mi17_HIP_CA.paa";
+	Icon = "\ca\air\data\map_ico\icomap_mi17_CA.paa";
+	mapSize = 25;
+	accuracy = 1000;	// accuracy needed to recognize type of this target
+	weapons[] = {"CMFlareLauncher"};
+	magazines[] = {"120Rnd_CMFlareMagazine"};
+	LockDetectionSystem = 0;
+	IncommingMisslieDetectionSystem = 0;
+	gunnerUsesPilotView = true;
+	
+	// threat (VSoft, VArmor, VAir), how threatening vehicle is to unit types
+	threat[] = {1, 0.6, 0.3};
+
+	enableSweep = false;
+	
+	class Turrets : Turrets {
+		class LeftTurret : MainTurret {
+			proxyIndex = 2;
+			commanding = -1;
+			primaryGunner = 0;
+			gunnerName = $STR_POSITION_DOORGUNNER;
+			minElev = -50;
+			maxElev = 30;
+			initElev = 11;
+			minTurn = 20;
+			maxTurn = 155;
+			initTurn = 80;
+			magazines[] = {"100Rnd_762x54_PK"};
+		};
+		
+		class BackTurret : BackTurret {
+			gunnerName = $STR_POSITION_REARGUNNER;
+			primaryGunner = 1;
+			commanding = -3;
+			proxyIndex = 3;
+			gunnerAction = "Mi171_Gunner_EP1";
+			gunnerInAction = "Mi171_Gunner_EP1";
+			minTurn = 130;
+			maxTurn = 230;
+			initTurn = 180;
+			minElev = -50;
+			maxElev = 10;
+			initElev = 0;
+			magazines[] = {"100Rnd_762x54_PK"};
+		};
+		
+		class RightTurret : MainTurret {
+			proxyIndex = 1;
+			gunnerName = $STR_POSITION_CREWCHIEF;
+			body = "Turret_3";
+			gun = "Gun_3";
+			animationSourceBody = "Turret_3";
+			animationSourceGun = "Gun_3";
+			minElev = -60;
+			maxElev = 30;
+			initElev = 11;
+			minTurn = -155;
+			maxTurn = -30;
+			initTurn = -70;
+			weapons[] = {PKT_3};
+			stabilizedInAxes = "StabilizedInAxesNone";
+			gunBeg = "muzzle_3";	// endpoint of the gun
+			gunEnd = "chamber_3";	// chamber of the gun
+			gunnerAction = "Mi8_Gunner";
+			gunnerInAction = "Mi8_Gunner";
+			memoryPointGun = "muzzle_3";
+			memoryPointGunnerOptics = "gunnerview3";
+			selectionFireAnim = "zasleh3";
+			primaryGunner = 0;
+			commanding = -1;
+			magazines[] = {"100Rnd_762x54_PK"};
+		};
+	};
+	
+	class AnimationSources : AnimationSources {
+		class HUDaction {
+			source = "user";
+			animPeriod = 2;
+			initPhase = 0;
+		};
+		
+		class HUDaction_Hide : HUDaction {};
+		
+		class ReloadAnim_3 {
+			source = "reload";
+			weapon = PKT_3;
+		};
+		
+		class ReloadMagazine_3 {
+			source = "reloadmagazine";
+			weapon = PKT_3;
+		};
+		
+		class Revolving_3 {
+			source = "revolving";
+			weapon = PKT_3;
+		};
+		
+		class HIDE_weapon_holders {
+			source = "user";
+			animPeriod = 1e-007;
+			initPhase = 1;
+		};
+		
+		class HIDE_front_armor : HIDE_weapon_holders {
+			initPhase = 1;
+		};
+		
+		class HIDE_exhaust : HIDE_weapon_holders {
+			initPhase = 1;
+		};
+	};
+	
+	class UserActions {
+		class HUDoff {
+			displayName = $STR_AM_HUDON;
+			displayNameDefault = $STR_AM_HUDON;
+			position = "zamerny";
+			radius = 1;
+			onlyForPlayer = 1;
+			condition = "(player==driver this)and(this animationphase ""HUDAction"" !=0)";
+			statement = "this animate [""HUDAction"",0];this animate [""HUDaction_Hide"",0]";
+		};
+		
+		class HUDon {
+			displayName = $STR_AM_HUDOFF;
+			displayNameDefault = $STR_AM_HUDOFF;
+			position = "zamerny";
+			radius = 1;
+			onlyForPlayer = 1;
+			condition = "(player==driver this)and(this animationphase ""HUDAction"" !=1)";
+			statement = "this animate [""HUDAction"",1];this animate [""HUDaction_Hide"",1]";
 		};
 	};
 };

--- a/SQF/dayz_code/Configs/CfgVehicles/Helicopter/MI17.hpp
+++ b/SQF/dayz_code/Configs/CfgVehicles/Helicopter/MI17.hpp
@@ -10,7 +10,7 @@ class Mi17_base: Helicopter  {
 		};
 	};
 };
-
+//Armed
 class Mi17_DZ: Mi17_base	 {
 	displayname = $STR_VEH_NAME_MI17;
 	displaynameshort = "Mi17_DZ";
@@ -49,6 +49,125 @@ class Mi17_DZE: Mi17_DZ	 {
 	};
 };
 
+class Mi17_TK_EP1: Mi17_base  {};
+class Mi17_TK_EP1_DZ: Mi17_TK_EP1  {
+	displayname = "Mi17_TK_DZ";
+	displaynameshort = "Mi17_TK_DZ";
+	scope = public;
+	side = 2;
+	crew = "";
+	typicalCargo[] = {};
+	class TransportMagazines{};
+	class TransportWeapons{};
+	commanderCanSee = 2+16+32;
+	gunnerCanSee = 2+16+32;
+	driverCanSee = 2+16+32;
+	transportMaxWeapons = 10;
+	transportMaxMagazines = 50;
+	transportmaxbackpacks = 10;
+	fuelCapacity = 1870;
+
+	class Turrets : Turrets  {
+		class MainTurret : MainTurret  {
+			magazines[] = {"100Rnd_762x54_PK"};
+		};
+		class BackTurret : BackTurret {
+			magazines[] = {"100Rnd_762x54_PK"};
+		};
+	};
+};
+class Mi17_TK_EP1_DZE: Mi17_TK_EP1_DZ	 {
+	displaynameshort = "Mi17_TK_DZE";
+	class Turrets : Turrets  {
+		class MainTurret : MainTurret  {
+			magazines[] = {};
+		};
+		class BackTurret : BackTurret {
+			magazines[] = {};
+		};
+	};
+};
+
+class Mi17_UN_CDF_EP1: Mi17_base  {};
+class Mi17_UN_CDF_EP1_DZ: Mi17_UN_CDF_EP1  {
+	displayname = "Mi17_UN_CDF_EP1_DZ";
+	displaynameshort = "Mi17_UN_CDF_EP1_DZ";
+	scope = public;
+	side = 2;
+	crew = "";
+	typicalCargo[] = {};
+	class TransportMagazines{};
+	class TransportWeapons{};
+	commanderCanSee = 2+16+32;
+	gunnerCanSee = 2+16+32;
+	driverCanSee = 2+16+32;
+	transportMaxWeapons = 10;
+	transportMaxMagazines = 50;
+	transportmaxbackpacks = 10;
+	fuelCapacity = 1870;
+
+	class Turrets : Turrets  {
+		class MainTurret : MainTurret  {
+			magazines[] = {"100Rnd_762x54_PK"};
+		};
+		class BackTurret : BackTurret {
+			magazines[] = {"100Rnd_762x54_PK"};
+		};
+	};
+};
+
+class Mi17_UN_CDF_EP1_DZE: Mi17_UN_CDF_EP1_DZ	 {
+	displaynameshort = "Mi17_UN_CDF_EP1_DZE";
+	class Turrets : Turrets  {
+		class MainTurret : MainTurret  {
+			magazines[] = {};
+		};
+		class BackTurret : BackTurret {
+			magazines[] = {};
+		};
+	};
+};
+
+class Mi17_CDF: Mi17_base  {};
+class Mi17_CDF_DZ: Mi17_CDF  {
+	displayname = "Mi17_CDF_DZ";
+	displaynameshort = "Mi17_CDF_DZ";
+	scope = public;
+	side = 2;
+	crew = "";
+	typicalCargo[] = {};
+	class TransportMagazines{};
+	class TransportWeapons{};
+	commanderCanSee = 2+16+32;
+	gunnerCanSee = 2+16+32;
+	driverCanSee = 2+16+32;
+	transportMaxWeapons = 10;
+	transportMaxMagazines = 50;
+	transportmaxbackpacks = 10;
+	fuelCapacity = 1870;
+
+	class Turrets : Turrets  {
+		class MainTurret : MainTurret  {
+			magazines[] = {"100Rnd_762x54_PK"};
+		};
+		class BackTurret : BackTurret {
+			magazines[] = {"100Rnd_762x54_PK"};
+		};
+	};
+};
+class Mi17_CDF_DZE: Mi17_CDF_DZ	 {
+	displaynameshort = "Mi17_CDF_DZE";
+	class Turrets : Turrets  {
+		class MainTurret : MainTurret  {
+			magazines[] = {};
+		};
+		class BackTurret : BackTurret {
+			magazines[] = {};
+		};
+	};
+};
+
+//Unarmed
 class Mi17_Civilian;
 class Mi17_Civilian_DZ: Mi17_Civilian	 {
 	displayname = "Mi-17 (Civilian)";
@@ -65,4 +184,61 @@ class Mi17_Civilian_DZ: Mi17_Civilian	 {
 	transportMaxWeapons = 10;
 	transportMaxMagazines = 50;
 	transportmaxbackpacks = 10;
+};
+
+class Mi17_medevac_CDF;
+class Mi17_medevac_CDF_DZ: Mi17_medevac_CDF {
+	displayname = "Mi-17 MedEvac (CDF)";
+	displaynameshort = "Mi-17 MedEvac (CDF)";
+	scope = public;
+	side = 3;
+	crew = "";
+	typicalCargo[] = {};
+	class TransportMagazines{};
+	class TransportWeapons{};
+	commanderCanSee = 2+16+32;
+	gunnerCanSee = 2+16+32;
+	driverCanSee = 2+16+32;
+	transportMaxWeapons = 10;
+	transportMaxMagazines = 50;
+	transportmaxbackpacks = 10;
+	fuelCapacity = 1500;
+};
+
+class Mi17_medevac_Ins;
+class Mi17_medevac_Ins_DZ: Mi17_medevac_Ins {
+	displayname = "Mi-17 MedEvac (Ins)";
+	displaynameshort = "Mi-17 MedEvac (Ins)";
+	scope = public;
+	side = 3;
+	crew = "";
+	typicalCargo[] = {};
+	class TransportMagazines{};
+	class TransportWeapons{};
+	commanderCanSee = 2+16+32;
+	gunnerCanSee = 2+16+32;
+	driverCanSee = 2+16+32;
+	transportMaxWeapons = 10;
+	transportMaxMagazines = 50;
+	transportmaxbackpacks = 10;
+	fuelCapacity = 1500;
+};
+
+class Mi17_medevac_RU;
+class Mi17_medevac_RU_DZ: Mi17_medevac_RU {
+	displayname = "Mi-17 MedEvac (RU)";
+	displaynameshort = "Mi-17 MedEvac (RU)";
+	scope = public;
+	side = 3;
+	crew = "";
+	typicalCargo[] = {};
+	class TransportMagazines{};
+	class TransportWeapons{};
+	commanderCanSee = 2+16+32;
+	gunnerCanSee = 2+16+32;
+	driverCanSee = 2+16+32;
+	transportMaxWeapons = 10;
+	transportMaxMagazines = 50;
+	transportmaxbackpacks = 10;
+	fuelCapacity = 1500;
 };

--- a/SQF/dayz_code/Configs/CfgVehicles/Helicopter/UH60.hpp
+++ b/SQF/dayz_code/Configs/CfgVehicles/Helicopter/UH60.hpp
@@ -554,6 +554,8 @@ class UH60M_EP1_DZE: UH60M_US_base_EP1 {
 // Unarmed medevac
 class UH60M_MEV_EP1;
 class UH60M_MEV_EP1_DZ : UH60M_MEV_EP1 {
+	displayname = "HH-60M MedEvac";
+	displaynameshort = "HH-60M MedEvac";
 	scope = public; 
 	crew = ""; 
 	typicalCargo[] = {}; 
@@ -563,7 +565,6 @@ class UH60M_MEV_EP1_DZ : UH60M_MEV_EP1 {
 	transportMaxWeapons = 10;
 	transportMaxMagazines = 100;
 	transportMaxBackpacks = 5;
-	
 	side = 1;
 	faction = "USMC";
 	accuracy = 0.5;

--- a/SQF/dayz_code/Configs/CfgVehicles/Helicopter/UH60.hpp
+++ b/SQF/dayz_code/Configs/CfgVehicles/Helicopter/UH60.hpp
@@ -554,8 +554,8 @@ class UH60M_EP1_DZE: UH60M_US_base_EP1 {
 // Unarmed medevac
 class UH60M_MEV_EP1;
 class UH60M_MEV_EP1_DZ : UH60M_MEV_EP1 {
-	displayname = "HH-60M MedEvac";
-	displaynameshort = "HH-60M MedEvac";
+	displayname = "UH-60M MedEvac";
+	displaynameshort = "UH-60M MedEvac";
 	scope = public; 
 	crew = ""; 
 	typicalCargo[] = {}; 

--- a/SQF/dayz_code/Configs/CfgVehicles/Plane/AN2_DZ.hpp
+++ b/SQF/dayz_code/Configs/CfgVehicles/Plane/AN2_DZ.hpp
@@ -31,3 +31,26 @@ class AN2_2_DZ : AN2_DZ
 		"ca\Air_E\An2\Data\an2_wings_A_CO"
 	};
 };
+
+class An2_2_TK_CIV_EP1: An2_Base_EP1 {};
+class An2_2_TK_CIV_EP1_DZ : An2_2_TK_CIV_EP1
+{
+	displayname = $STR_VEH_NAME_AN2;
+	displaynameshort = $STR_EP1_DN_AN2_TK;
+	scope = public;
+	side = 2;
+	crew = "";
+	typicalCargo[] = {};
+	class TransportMagazines{};
+	class TransportWeapons{};
+	weapons[] = {};
+	magazines[] = {};
+	gunnerHasFlares = false;
+	commanderCanSee = 2+16+32;
+	gunnerCanSee = 2+16+32;
+	driverCanSee = 2+16+32;
+	transportMaxWeapons = 10;
+	transportMaxMagazines = 80;
+	transportmaxbackpacks = 15;
+	fuelCapacity = 757;
+};

--- a/SQF/dayz_code/Configs/CfgVehicles/Plane/AN2_DZ.hpp
+++ b/SQF/dayz_code/Configs/CfgVehicles/Plane/AN2_DZ.hpp
@@ -32,7 +32,7 @@ class AN2_2_DZ : AN2_DZ
 	};
 };
 
-class An2_2_TK_CIV_EP1: An2_Base_EP1 {};
+class An2_2_TK_CIV_EP1;
 class An2_2_TK_CIV_EP1_DZ : An2_2_TK_CIV_EP1
 {
 	displayname = $STR_VEH_NAME_AN2;

--- a/SQF/dayz_code/Configs/CfgVehicles/Plane/Cessna_DZ.hpp
+++ b/SQF/dayz_code/Configs/CfgVehicles/Plane/Cessna_DZ.hpp
@@ -1,0 +1,84 @@
+class GNT_C185C;
+class GNT_C185C_DZ: GNT_C185C
+{
+	displayname = "GNT_C185C_DZ";
+	displaynameshort = "GNT_C185C_DZ";
+	scope = public;
+	side = 2;
+	crew = "";
+	typicalCargo[] = {};
+	hiddenSelections[] = {};
+	class TransportMagazines{};
+	class TransportWeapons{};
+	weapons[] = {};
+	magazines[] = {};
+	gunnerHasFlares = false;
+	commanderCanSee = 2+16+32;
+	gunnerCanSee = 2+16+32;
+	driverCanSee = 2+16+32;
+	fuelCapacity = 1000;
+};
+
+class GNT_C185R;
+class GNT_C185R_DZ: GNT_C185R
+{
+	displayname = "GNT_C185R_DZ";
+	displaynameshort = "GNT_C185R_DZ";
+	scope = public;
+	side = 2;
+	crew = "";
+	typicalCargo[] = {};
+	hiddenSelections[] = {};
+	class TransportMagazines{};
+	class TransportWeapons{};
+	weapons[] = {};
+	magazines[] = {};
+	gunnerHasFlares = false;
+	commanderCanSee = 2+16+32;
+	gunnerCanSee = 2+16+32;
+	driverCanSee = 2+16+32;
+	fuelCapacity = 1000;
+};
+
+class GNT_C185;
+class GNT_C185_DZ: GNT_C185
+{
+	displayname = "GNT_C185_DZ";
+	displaynameshort = "GNT_C185_DZ";
+	scope = public;
+	side = 2;
+	crew = "";
+	typicalCargo[] = {};
+	hiddenSelections[] = {};
+	class TransportMagazines{};
+	class TransportWeapons{};
+	weapons[] = {};
+	magazines[] = {};
+	gunnerHasFlares = false;
+	commanderCanSee = 2+16+32;
+	gunnerCanSee = 2+16+32;
+	driverCanSee = 2+16+32;
+	fuelCapacity = 1000;
+};
+
+class GNT_C185U;
+class GNT_C185U_DZ: GNT_C185U
+{
+	displayname = "GNT_C185U_DZ";
+	displaynameshort = "GNT_C185U_DZ";
+	scope = public;
+	side = 2;
+	crew = "";
+	typicalCargo[] = {};
+	hiddenSelections[] = {};
+	class TransportMagazines{};
+	class TransportWeapons{};
+	weapons[] = {};
+	magazines[] = {};
+	gunnerHasFlares = false;
+	commanderCanSee = 2+16+32;
+	gunnerCanSee = 2+16+32;
+	driverCanSee = 2+16+32;
+	fuelCapacity = 1000;
+};
+

--- a/SQF/dayz_code/Configs/CfgVehicles/Plane/Cessna_DZ.hpp
+++ b/SQF/dayz_code/Configs/CfgVehicles/Plane/Cessna_DZ.hpp
@@ -3,20 +3,16 @@ class GNT_C185C_DZ: GNT_C185C
 {
 	displayname = "GNT_C185C_DZ";
 	displaynameshort = "GNT_C185C_DZ";
-	scope = public;
 	side = 2;
 	crew = "";
 	typicalCargo[] = {};
-	hiddenSelections[] = {};
 	class TransportMagazines{};
 	class TransportWeapons{};
-	weapons[] = {};
-	magazines[] = {};
 	gunnerHasFlares = false;
 	commanderCanSee = 2+16+32;
 	gunnerCanSee = 2+16+32;
 	driverCanSee = 2+16+32;
-	fuelCapacity = 1000;
+	fuelCapacity = 700;
 };
 
 class GNT_C185R;
@@ -24,20 +20,16 @@ class GNT_C185R_DZ: GNT_C185R
 {
 	displayname = "GNT_C185R_DZ";
 	displaynameshort = "GNT_C185R_DZ";
-	scope = public;
 	side = 2;
 	crew = "";
 	typicalCargo[] = {};
-	hiddenSelections[] = {};
 	class TransportMagazines{};
 	class TransportWeapons{};
-	weapons[] = {};
-	magazines[] = {};
 	gunnerHasFlares = false;
 	commanderCanSee = 2+16+32;
 	gunnerCanSee = 2+16+32;
 	driverCanSee = 2+16+32;
-	fuelCapacity = 1000;
+	fuelCapacity = 700;
 };
 
 class GNT_C185;
@@ -45,20 +37,16 @@ class GNT_C185_DZ: GNT_C185
 {
 	displayname = "GNT_C185_DZ";
 	displaynameshort = "GNT_C185_DZ";
-	scope = public;
 	side = 2;
 	crew = "";
 	typicalCargo[] = {};
-	hiddenSelections[] = {};
 	class TransportMagazines{};
 	class TransportWeapons{};
-	weapons[] = {};
-	magazines[] = {};
 	gunnerHasFlares = false;
 	commanderCanSee = 2+16+32;
 	gunnerCanSee = 2+16+32;
 	driverCanSee = 2+16+32;
-	fuelCapacity = 1000;
+	fuelCapacity = 700;
 };
 
 class GNT_C185U;
@@ -66,19 +54,15 @@ class GNT_C185U_DZ: GNT_C185U
 {
 	displayname = "GNT_C185U_DZ";
 	displaynameshort = "GNT_C185U_DZ";
-	scope = public;
 	side = 2;
 	crew = "";
 	typicalCargo[] = {};
-	hiddenSelections[] = {};
 	class TransportMagazines{};
 	class TransportWeapons{};
-	weapons[] = {};
-	magazines[] = {};
 	gunnerHasFlares = false;
 	commanderCanSee = 2+16+32;
 	gunnerCanSee = 2+16+32;
 	driverCanSee = 2+16+32;
-	fuelCapacity = 1000;
+	fuelCapacity = 700;
 };
 


### PR DESCRIPTION
Ive added a lot new vehicles to the epoch configs. Most of the vehicle are used already by many admins but the vehicles have minmal cargo space, the radar function armor a way to high. I changed all vehicles to make them playable for epoch. Im not that good in that cfgVehicle thing so im not sure there are an easier ways to get the vehicles working.
Currently I did not add them to the traders. I would be fine with that but Im not sure what you guys think? 

HMMWV and BRDM2: I did not get the non ammo version working. Can someone take that part? I balanced the BRDM2 with the specs from the Vodnic. It has more fuel now but less armor.

New vehicles:

BRDM2_HQ_TK_GUE_EP1
HMMWV_Armored
HMMWV_M2

Mi17_TK_EP1
Mi17_UN_CDF_EP1
Mi17_CDF
Mi17_medevac_CDF
Mi17_medevac_Ins
Mi17_medevac_RU

An2_2_TK_CIV_EP1

I want to add at last the Mi171Sh_CZ_EP1 but I did not get it working with the turrets.

The Cessnas have no more the radar function, thats why I added them to the configs.