### PR TITLE
Supply crate localization fixes

### DIFF
--- a/SQF/dayz_code/Configs/CfgMagazines/DZE/Bulk.hpp
+++ b/SQF/dayz_code/Configs/CfgMagazines/DZE/Bulk.hpp
@@ -9,6 +9,7 @@ class bulk: CA_Magazine {
 	weight = 5;
 };
 class bulk_empty: bulk {
+	displayName = $STR_EPOCH_BULK_DISP_EMPTY;
 	descriptionShort = $STR_EPOCH_BULK_DESC_EMPTY;
 	weight = 5;
 	class ItemActions {
@@ -65,6 +66,7 @@ class bulk_empty: bulk {
 };
 
 class bulk_ItemSodaCoke: bulk {
+	displayName = $STR_EPOCH_BULK_DISP_SODACOKE_HALF;
 	descriptionShort = $STR_EPOCH_BULK_DESC_SODACOKE_HALF;
 	weight = 6;
 	class ItemActions {
@@ -84,6 +86,7 @@ class bulk_ItemSodaCoke: bulk {
 	};
 };
 class bulk_ItemSodaCokeFull: bulk {
+	displayName = $STR_EPOCH_BULK_DISP_SODACOKE_FULL;
 	descriptionShort = $STR_EPOCH_BULK_DESC_SODACOKE_FULL;
 	weight = 7;
 	class ItemActions {
@@ -96,6 +99,7 @@ class bulk_ItemSodaCokeFull: bulk {
 };
 
 class bulk_ItemSodaPepsi: bulk {
+	displayName = $STR_EPOCH_BULK_DISP_SODAPEPSI_HALF;
 	descriptionShort = $STR_EPOCH_BULK_DESC_SODAPEPSI_HALF;
 	weight = 6;
 	class ItemActions {
@@ -115,6 +119,7 @@ class bulk_ItemSodaPepsi: bulk {
 	};
 };
 class bulk_ItemSodaPepsiFull: bulk {
+	displayName = $STR_EPOCH_BULK_DISP_SODAPEPSI_FULL;
 	descriptionShort = $STR_EPOCH_BULK_DESC_SODAPEPSI_FULL;
 	weight = 7;
 	class ItemActions {
@@ -127,6 +132,7 @@ class bulk_ItemSodaPepsiFull: bulk {
 };
 
 class bulk_FoodbaconCooked: bulk {
+	displayName = $STR_EPOCH_BULK_DISP_BACON_HALF;
 	descriptionShort = $STR_EPOCH_BULK_DESC_BACON_HALF;
 	weight = 5;
 	class ItemActions {
@@ -146,6 +152,7 @@ class bulk_FoodbaconCooked: bulk {
 	};
 };
 class bulk_FoodbaconCookedFull: bulk {
+	displayName = $STR_EPOCH_BULK_DISP_BACON_FULL;
 	descriptionshort = $STR_EPOCH_BULK_DESC_BACON_FULL;
 	weight = 5;
 	class ItemActions {
@@ -159,6 +166,7 @@ class bulk_FoodbaconCookedFull: bulk {
 
 // Ammo
 class bulk_17Rnd_9x19_glock17: bulk {
+	displayName = $STR_EPOCH_BULK_DISP_G17;
 	descriptionShort = $STR_EPOCH_BULK_DESC_G17;
 	weight = 17;
 	class ItemActions {
@@ -170,6 +178,7 @@ class bulk_17Rnd_9x19_glock17: bulk {
 	};
 };
 class bulk_15Rnd_9x19_M9SD: bulk {
+	displayName = $STR_EPOCH_BULK_DISP_M9SD;
 	descriptionShort = $STR_EPOCH_BULK_DESC_M9SD;
 	weight = 17;
 	class ItemActions {
@@ -181,6 +190,7 @@ class bulk_15Rnd_9x19_M9SD: bulk {
 	};
 };
 class bulk_30Rnd_9x19_MP5SD: bulk {
+	displayName = $STR_EPOCH_BULK_DISP_MP5SD;
 	descriptionShort = $STR_EPOCH_BULK_DESC_MP5SD;
 	weight = 18;
 	class ItemActions {
@@ -192,6 +202,7 @@ class bulk_30Rnd_9x19_MP5SD: bulk {
 	};
 };
 class bulk_30Rnd_556x45_StanagSD: bulk {
+	displayName = $STR_EPOCH_BULK_DISP_STANAGSD;
 	descriptionShort = $STR_EPOCH_BULK_DESC_STANAGSD;
 	weight = 20;
 	class ItemActions {
@@ -204,6 +215,7 @@ class bulk_30Rnd_556x45_StanagSD: bulk {
 };
 
 class bulk_ItemSandbag: bulk {
+	displayName = $STR_EPOCH_BULK_DISP_SANDBAG;
 	descriptionShort = $STR_EPOCH_BULK_DESC_SANDBAG;
 	weight = 60;
 	class ItemActions {
@@ -216,6 +228,7 @@ class bulk_ItemSandbag: bulk {
 };
 
 class bulk_ItemTankTrap: bulk {
+	displayName = $STR_EPOCH_BULK_DISP_TANKTRAP_FULL;
 	descriptionShort = $STR_EPOCH_BULK_DESC_TANKTRAP_FULL;
 	weight = 25;
 	class ItemActions {
@@ -227,6 +240,7 @@ class bulk_ItemTankTrap: bulk {
 	};
 };
 class bulk_ItemTankTrapHalf: bulk {
+	displayName = $STR_EPOCH_BULK_DISP_TANKTRAP_HALF;
 	descriptionShort = $STR_EPOCH_BULK_DESC_TANKTRAP_HALF;
 	weight = 12.5;
 	class ItemActions {
@@ -247,6 +261,7 @@ class bulk_ItemTankTrapHalf: bulk {
 };
 
 class bulk_ItemWire: bulk {
+	displayName = $STR_EPOCH_BULK_DISP_WIREKIT_FULL;
 	descriptionShort = $STR_EPOCH_BULK_DESC_WIREKIT_FULL;
 	weight = 25;
 	class ItemActions {
@@ -258,6 +273,7 @@ class bulk_ItemWire: bulk {
 	};
 };
 class bulk_ItemWireHalf: bulk {
+	displayName = $STR_EPOCH_BULK_DISP_WIREKIT_HALF;
 	descriptionShort = $STR_EPOCH_BULK_DESC_WIREKIT_HALF;
 	weight = 12.5;
 	class ItemActions {
@@ -278,6 +294,7 @@ class bulk_ItemWireHalf: bulk {
 };
 
 class bulk_PartGeneric: bulk {
+	displayName = $STR_EPOCH_BULK_DISP_GENERIC_FULL;
 	descriptionShort = $STR_EPOCH_BULK_DESC_GENERIC_FULL;
 	weight = 60;
 	class ItemActions {
@@ -289,6 +306,7 @@ class bulk_PartGeneric: bulk {
 	};
 };
 class bulk_PartGenericHalf: bulk {
+	displayName = $STR_EPOCH_BULK_DISP_GENERIC_HALF;
 	descriptionShort = $STR_EPOCH_BULK_DESC_GENERIC_HALF;
 	weight = 30;
 	class ItemActions {

--- a/SQF/dayz_code/Configs/RscDisplay/RscDisplayGear.hpp
+++ b/SQF/dayz_code/Configs/RscDisplay/RscDisplayGear.hpp
@@ -235,19 +235,20 @@ class RscDisplayGear
 			shadow = 0;
 		};
 		
-		class CA_ItemName : RscText
+		class CA_ItemName : RscText // This is the RSC for the DisplayName under the list box.
 		{
 			idc = 1101;
 			//x = -0.039;
 			x = -0.051;
 			//y = 0.627;
 			y = 0.668;
+			w = 0.458;
 			colorText[] = {0.32,0.24,0.09,1};
 			shadow = 0;
 			text = "Gear of the unit:";
 		};
 		
-		class CA_CustomDescription : RscStructuredText
+		class CA_CustomDescription : RscStructuredText // This is the RSC for the descriptionShort under the list box.
 		{
 			idc = 1106;
 			//x = -0.039;

--- a/SQF/dayz_code/stringtable.xml
+++ b/SQF/dayz_code/stringtable.xml
@@ -13547,8 +13547,8 @@
 			<Czech>Bedna zásob</Czech>
 		</Key>
 		<Key ID="STR_EPOCH_BULK_DESC">
-			<English>12 x Random Item</English>
-			<German>12 x Zufällige Gegenstände</German>
+			<English>12x Random Item</English>
+			<German>12x Zufällige Gegenstände</German>
 			<Russian>Какой-то предмет (12x)</Russian>
 			<Czech>12x Náhodných předmětů</Czech>
 		</Key>
@@ -13558,95 +13558,149 @@
 			<Russian>Пустой ящик</Russian>
 			<Czech>Prázdná bedna</Czech>
 		</Key>
+		<Key ID="STR_EPOCH_BULK_DISP_EMPTY">
+			<English>Supply Crate (Empty)</English>
+		</Key>
 		<Key ID="STR_EPOCH_BULK_DESC_SODACOKE_HALF">
-			<English>6 x Soda (Coke)</English>
-			<German>6 x Dose (Coke)</German>
-			<Russian>6 x Газировка (Кола)</Russian>
+			<English>6x Soda (Coke)</English>
+			<German>6x Dose (Coke)</German>
+			<Russian>6x Газировка (Кола)</Russian>
 			<Czech>6x Soda s kolovou příchutí</Czech>
 		</Key>
+		<Key ID="STR_EPOCH_BULK_DISP_SODACOKE_HALF">
+			<English>Supply Crate (6x Coke)</English>
+		</Key>
 		<Key ID="STR_EPOCH_BULK_DESC_SODACOKE_FULL">
-			<English>12 x Soda (Coke)</English>
-			<German>12 x Dose (Coke)</German>
-			<Russian>12 x Газировка (Кола)</Russian>
+			<English>12x Soda (Coke)</English>
+			<German>12x Dose (Coke)</German>
+			<Russian>12x Газировка (Кола)</Russian>
 			<Czech>12x Soda s kolovou příchutí</Czech>
 		</Key>
+		<Key ID="STR_EPOCH_BULK_DISP_SODACOKE_FULL">
+			<English>Supply Crate (12x Coke)</English>
+		</Key>
 		<Key ID="STR_EPOCH_BULK_DESC_SODAPEPSI_HALF">
-			<English>6 x Soda (Pepsi)</English>
-			<German>6 x Dose (Pepsi)</German>
-			<Russian>6 x Газировка (Пепси)</Russian>
+			<English>6x Soda (Pepsi)</English>
+			<German>6x Dose (Pepsi)</German>
+			<Russian>6x Газировка (Пепси)</Russian>
 			<Czech>6x Pepsi</Czech>
 		</Key>
+		<Key ID="STR_EPOCH_BULK_DISP_SODAPEPSI_HALF">
+			<English>Supply Crate (6x Pepsi)</English>
+		</Key>
 		<Key ID="STR_EPOCH_BULK_DESC_SODAPEPSI_FULL">
-			<English>12 x Soda (Pepsi)</English>
-			<German>12 x Dose (Pepsi)</German>
-			<Russian>12 x Газировка (Пепси)</Russian>
+			<English>12x Soda (Pepsi)</English>
+			<German>12x Dose (Pepsi)</German>
+			<Russian>12x Газировка (Пепси)</Russian>
 			<Czech>12x Pepsi</Czech>
 		</Key>
+		<Key ID="STR_EPOCH_BULK_DISP_SODAPEPSI_FULL">
+			<English>Supply Crate (12x Pepsi)</English>
+		</Key>
 		<Key ID="STR_EPOCH_BULK_DESC_BACON_HALF">
-			<English>6 x Bacon</English>
-			<German>6 x Gebratener Speck</German>
-			<Russian>6 x Готовый бекон</Russian>
+			<English>6x Bacon</English>
+			<German>6x Gebratener Speck</German>
+			<Russian>6x Готовый бекон</Russian>
 			<Czech>6x Vepřové</Czech>
 		</Key>
+		<Key ID="STR_EPOCH_BULK_DISP_BACON_HALF">
+			<English>Supply Crate (6x Bacon)</English>
+		</Key>
 		<Key ID="STR_EPOCH_BULK_DESC_BACON_FULL">
-			<English>12 x Bacon</English>
-			<German>12 x Gebratener Speck</German>
-			<Russian>12 x Готовый бекон</Russian>
+			<English>12x Bacon</English>
+			<German>12x Gebratener Speck</German>
+			<Russian>12x Готовый бекон</Russian>
 			<Czech>12x Vepřové</Czech>
 		</Key>
+		<Key ID="STR_EPOCH_BULK_DISP_BACON_FULL">
+			<English>Supply Crate (12x Bacon)</English>
+		</Key>
 		<Key ID="STR_EPOCH_BULK_DESC_G17">
-			<English>12 x 17Rnd_9x19_glock17</English>
-			<Czech>12x 17Rnd_9x19_glock17</Czech>
+			<English>12x 17Rnd_9x19_glock17</English>
+		</Key>
+		<Key ID="STR_EPOCH_BULK_DISP_G17">
+			<English>Supply Crate (12x G17)</English>
 		</Key>
 		<Key ID="STR_EPOCH_BULK_DESC_M9SD">
-			<English>12 x 15Rnd_9x19_M9SD</English>
-			<Czech>12x 15Rnd_9x19_M9SD</Czech>
+			<English>12x 15Rnd_9x19_M9SD</English>
+		</Key>
+		<Key ID="STR_EPOCH_BULK_DISP_M9SD">
+			<English>Supply Crate (12x M9SD)</English>
 		</Key>
 		<Key ID="STR_EPOCH_BULK_DESC_MP5SD">
-			<English>12 x 30Rnd_9x19_MP5SD</English>
-			<Czech>12x 30Rnd_9x19_MP5SD</Czech>
+			<English>12x 30Rnd_9x19_MP5SD</English>
+		</Key>
+		<Key ID="STR_EPOCH_BULK_DISP_MP5SD">
+			<English>Supply Crate (12x MP5SD)</English>
+		</Key>
+		<Key ID="STR_EPOCH_BULK_DESC_STANAGSD">
+			<English>12x 30Rnd_556x45_StanagSD</English>
+		</Key>
+		<Key ID="STR_EPOCH_BULK_DISP_STANAGSD">
+			<English>Supply Crate (12x StanagSD)</English>
 		</Key>
 		<Key ID="STR_EPOCH_BULK_DESC_SANDBAG">
-			<English>12 x SandBag</English>
-			<German>12 x Sandsack</German>
-			<Russian>12 x Мешок с песком</Russian>
+			<English>12x SandBag</English>
+			<German>12x Sandsack</German>
+			<Russian>12x Мешок с песком</Russian>
 			<Czech>12 Pytlů s pískem</Czech>
 		</Key>
-		<Key ID="STR_EPOCH_BULK_DESC_TANKTRAP_HALF">
-			<English>6 x Tank Trap</English>
-			<German>6 x Panzersperre</German>
-			<Russian>6 x Противотанковый ёж</Russian>
-			<Czech>6 Zátaras</Czech>
+		<Key ID="STR_EPOCH_BULK_DISP_SANDBAG">
+			<English>Supply Crate (12x Sandbag)</English>
 		</Key>
 		<Key ID="STR_EPOCH_BULK_DESC_TANKTRAP_FULL">
-			<English>12 x Tank Trap</English>
-			<German>12 x Panzersperre</German>
-			<Russian>12 x Противотанковый ёж</Russian>
+			<English>12x Tank Trap</English>
+			<German>12x Panzersperre</German>
+			<Russian>12x Противотанковый ёж</Russian>
 			<Czech>12 Zátaras</Czech>
 		</Key>
-		<Key ID="STR_EPOCH_BULK_DESC_WIREKIT_HALF">
-			<English>6 x Wire Kit</English>
-			<German>6 x Stacheldraht</German>
-			<Russian>6 x Колючая проволока</Russian>
-			<Czech>6 Drátů</Czech>
+		<Key ID="STR_EPOCH_BULK_DISP_TANKTRAP_FULL">
+			<English>Supply Crate (12x Tank Trap)</English>
+		</Key>
+		<Key ID="STR_EPOCH_BULK_DESC_TANKTRAP_HALF">
+			<English>6x Tank Trap</English>
+			<German>6x Panzersperre</German>
+			<Russian>6x Противотанковый ёж</Russian>
+			<Czech>6 Zátaras</Czech>
+		</Key>
+		<Key ID="STR_EPOCH_BULK_DISP_TANKTRAP_HALF">
+			<English>Supply Crate (6x Tank Trap)</English>
 		</Key>
 		<Key ID="STR_EPOCH_BULK_DESC_WIREKIT_FULL">
-			<English>12 x Wire Kit</English>
-			<German>12 x Stacheldraht</German>
-			<Russian>12 x Колючая проволока</Russian>
+			<English>12x Wire Kit</English>
+			<German>12x Stacheldraht</German>
+			<Russian>12x Колючая проволока</Russian>
 			<Czech>12 Drátů</Czech>
 		</Key>
-		<Key ID="STR_EPOCH_BULK_DESC_GENERIC_HALF">
-			<English>6 x Scrap Metal</English>
-			<German>6 x Metallteile</German>
-			<Russian>6 x Металлолом</Russian>
-			<Czech>6x Železný šrot</Czech>
+		<Key ID="STR_EPOCH_BULK_DISP_WIREKIT_FULL">
+			<English>Supply Crate (12x Wire Kit)</English>
+		</Key>
+		<Key ID="STR_EPOCH_BULK_DESC_WIREKIT_HALF">
+			<English>6x Wire Kit</English>
+			<German>6x Stacheldraht</German>
+			<Russian>6x Колючая проволока</Russian>
+			<Czech>6 Drátů</Czech>
+		</Key>
+		<Key ID="STR_EPOCH_BULK_DISP_WIREKIT_HALF">
+			<English>Supply Crate (6x Wire Kit)</English>
 		</Key>
 		<Key ID="STR_EPOCH_BULK_DESC_GENERIC_FULL">
-			<English>12 x Scrap Metal</English>
-			<German>12 x Metallteile</German>
-			<Russian>12 x Металлолом</Russian>
+			<English>12x Scrap Metal</English>
+			<German>12x Metallteile</German>
+			<Russian>12x Металлолом</Russian>
 			<Czech>12x Železný šrot</Czech>
+		</Key>
+		<Key ID="STR_EPOCH_BULK_DISP_GENERIC_FULL">
+			<English>Supply Crate (12x Scrap Metal)</English>
+		</Key>
+		<Key ID="STR_EPOCH_BULK_DESC_GENERIC_HALF">
+			<English>6x Scrap Metal</English>
+			<German>6x Metallteile</German>
+			<Russian>6x Металлолом</Russian>
+			<Czech>6x Železný šrot</Czech>
+		</Key>
+		<Key ID="STR_EPOCH_BULK_DISP_GENERIC_HALF">
+			<English>Supply Crate (6x Scrap Metal)</English>
 		</Key>
 		<Key ID="STR_EPOCH_SAFE">
 			<English>Safe</English>
@@ -13833,9 +13887,6 @@
 			<English>Bio Meat</English>
 			<German>Bio-Fleisch</German>
 			<Russian>Органическое мясо</Russian>
-			<Spanish>Bio Meat</Spanish>
-			<French>Bio Meat</French>
-			<Czech>Bio Meat</Czech>
 		</Key>
 		<Key ID="STR_FOOD_NAME_BIOMEAT_DESC">
 			<English>Bio Meat: A very good source of nutrition, and a very high chance of infection. Eat at own risk.</English>


### PR DESCRIPTION
Extends the displayName RSC width to the same as the description (Not
sure why this was so small, it truncated longer display names)
Added localization strings for all the supply crates so they were easier
to distinguish in the gear menu.