### PR TITLE
Plot management force maintain option

### DIFF
--- a/SQF/dayz_code/Configs/RscDisplay/plotManagement.hpp
+++ b/SQF/dayz_code/Configs/RscDisplay/plotManagement.hpp
@@ -38,21 +38,21 @@ class PlotManagement
 		class RscShortcutButton_7010: ZSC_RscButtonMenuBlue
 		{
 			idc = -1;
-			text = $STR_EPOCH_REFRESH;
+			text = $STR_EPOCH_ACTIONS_MAINTAIN;
 			x = 0.41 * safezoneW + safezoneX;
 			y = 0.22 * safezoneH + safezoneY;
 			w = 0.08 * safezoneW;
-			onButtonClick = "'preview' call MaintainPlot;";
+			onButtonClick = "'maintain' call MaintainPlot;";
 		};
 
 		class RscShortcutButton_7011: ZSC_RscButtonMenuBlue
 		{
 			idc = -1;
-			text = $STR_EPOCH_ACTIONS_MAINTAIN;
+			text = $STR_EPOCH_ACTIONS_MAINTAIN_FORCE;
 			x = 0.51 * safezoneW + safezoneX;
 			y = 0.22 * safezoneH + safezoneY;
 			w = 0.08 * safezoneW;
-			onButtonClick = "'maintain' call MaintainPlot;";
+			onButtonClick = "'force' call MaintainPlot;";
 		};
 
 		class RscText_7012: ZSC_RscTextT

--- a/SQF/dayz_code/actions/plotManagement/maintain_area.sqf
+++ b/SQF/dayz_code/actions/plotManagement/maintain_area.sqf
@@ -1,4 +1,4 @@
-private ["_objectID","_objectUID","_target","_objectClasses","_range","_objects","_requirements","_count","_objects_filtered","_ctrl","_itemText","_type","_amount","_success","_wealth","_message1","_message2","_option"];
+private ["_objectID","_objectUID","_target","_objects","_requirements","_count","_objects_filtered","_ctrl","_itemText","_type","_amount","_success","_wealth","_message1","_message2","_option"];
 disableSerialization;
 
 if (dayz_actionInProgress) exitWith {localize "STR_EPOCH_ACTIONS_2" call dayz_rollingMessages;};
@@ -6,43 +6,24 @@ dayz_actionInProgress = true;
 
 player removeAction s_player_maintain_area;
 s_player_maintain_area = 1;
+player removeAction s_player_maintain_area_force;
+s_player_maintain_area_force = 1;
 player removeAction s_player_maintain_area_preview;
 s_player_maintain_area_preview = 1;
 
 _target = nearestObject [[player] call FNC_getPos,"Plastic_Pole_EP1_DZ"];
-_objectClasses = DZE_maintainClasses;
-_range = DZE_maintainRange; // set the max range for the maintain area
-_objects = nearestObjects [_target, _objectClasses, _range];
+_objects = nearestObjects [_target, DZE_maintainClasses, DZE_maintainRange];
 
 _objects_filtered = [];
-_count = 0;
-{
-    if (damage _x >= DZE_DamageBeforeMaint) then {
-		_objectUID = _x getVariable ["ObjectUID","0"];
-		_objectID = _x getVariable ["ObjectID","0"];
-		_objects_filtered set [count _objects_filtered, [_x, _objectID, _objectUID]];
-		_count = _count + 1;
-   };
-} count _objects;
-_objects = _objects_filtered;
-
-// TODO dynamic requirements based on used building parts?
-if (_count == 0) exitWith {
-	if (DZE_permanentPlot) then {
-		_ctrl = (uiNamespace getVariable "PlotManagement") displayCtrl 7012;
-		_ctrl ctrlSetText format[localize "STR_EPOCH_PLOTMANAGEMENT_MAINTAIN_OBJECTS", _count];
-		_ctrl = (uiNamespace getVariable "PlotManagement") displayCtrl 7013;
-		_ctrl ctrlSetText format[localize "STR_EPOCH_PLOTMANAGEMENT_NO_MONEY_NEEDED", " "];
-	} else {
-		format[localize "STR_EPOCH_ACTIONS_22",_count] call dayz_rollingMessages;
-	};
-	dayz_actionInProgress = false;
-	s_player_maintain_area = -1;
-	s_player_maintain_area_preview = -1;
-};
-
 _requirements = [];
-_requirements = switch true do {
+_count = 0;
+
+_req = {
+	private ["_count","_requirements","_type","_amount","_itemText","_wealth"];
+	_count = _this;
+	_wealth = 0;
+	
+	_requirements = switch true do {
 	case (_count <= 10):  {["ItemGoldBar10oz",1]};
 	case (_count <= 20):  {["ItemGoldBar10oz",2]};
 	case (_count <= 35):  {["ItemGoldBar10oz",3]};
@@ -57,81 +38,139 @@ _requirements = switch true do {
 	case (_count <= 550): {["ItemBriefcase100oz",7]};
 	case (_count <= 625): {["ItemBriefcase100oz",8]};
 	case (_count > 625):  {["ItemBriefcase100oz",9]};
-};
-
-_type = _requirements select 0;
-_amount = _requirements select 1;
-
-if (Z_SingleCurrency) then {
-	_amount = _count * 100;
-	_itemText = CurrencyName;
-	_wealth = player getVariable[Z_MoneyVariable,0];
-} else {
-	_itemText = getText(configFile >> "CfgMagazines" >> _type >> "displayName");
-	if ("ItemBriefcase100oz" == _type && _amount > 1) then {
-		_itemText = _itemText + "s";
 	};
-};
 
-_option = if (typeName _this == "ARRAY") then {_this select 3} else {_this};
-
-switch _option do {
-	case "maintain": {
-		_success = if (Z_SingleCurrency) then {_amount <= _wealth} else {[[[_type, _amount]],0] call epoch_returnChange};
-
-		if (_success) then {
-			player playActionNow "Medic";
-			[player,_range,true,(getPosATL player)] spawn player_alertZombies;
-			
-			if (Z_SingleCurrency) then {
-				player setVariable[Z_MoneyVariable,(_wealth - _amount),true];
-				call player_forceSave;
-			};
-
-			PVDZE_maintainArea = [player,1,_objects];
-			publicVariableServer "PVDZE_maintainArea";
-			
-			systemChat format[localize "STR_EPOCH_ACTIONS_4", _count];
-			_message1 = format[localize "STR_EPOCH_PLOTMANAGEMENT_OBJECTS_MAINTAINED_SUCCESS", _count];
-			_message2 = format[localize "STR_EPOCH_PLOTMANAGEMENT_PRICE_MAINTAINED_SUCCESS", [_amount] call BIS_fnc_numberText, _itemText];
-			if (DZE_permanentPlot) then {
-				_ctrl = (uiNamespace getVariable "PlotManagement") displayCtrl 7012;
-				_ctrl ctrlSetText _message1;
-				_ctrl = (uiNamespace getVariable "PlotManagement") displayCtrl 7013;
-				_ctrl ctrlSetText _message2;
-			} else {			
-				_message2 call dayz_rollingMessages;
-				_message1 call dayz_rollingMessages;
-			};
-		} else {
-			_message1 = format[localize "STR_EPOCH_PLOTMANAGEMENT_OBJECTS_MAINTAINED_FAILED", _count];
-			_message2 = format[localize "STR_EPOCH_PLOTMANAGEMENT_MONEY_NEEDED_FAILED", [_amount] call BIS_fnc_numberText, _itemText];
-			if (DZE_permanentPlot) then {
-				_ctrl = (uiNamespace getVariable "PlotManagement") displayCtrl 7012;
-				_ctrl ctrlSetText _message1;
-				_ctrl = (uiNamespace getVariable "PlotManagement") displayCtrl 7013;
-				_ctrl ctrlSetText _message2;
-			} else {
-				_message2 call dayz_rollingMessages;
-				_message1 call dayz_rollingMessages;
-			};
+	_type = _requirements select 0;
+	_amount = _requirements select 1;
+	
+	if (Z_SingleCurrency) then {
+		_amount = _count * 100;
+		_itemText = CurrencyName;
+		_wealth = player getVariable[Z_MoneyVariable,0];
+	} else {
+		_itemText = getText(configFile >> "CfgMagazines" >> _type >> "displayName");
+		if ("ItemBriefcase100oz" == _type && _amount > 1) then {
+			_itemText = _itemText + "s";
 		};
 	};
-	case "preview": {
-		_message1 = format[localize "STR_EPOCH_PLOTMANAGEMENT_MAINTAIN_OBJECTS", _count];
-		_message2 = format[localize "STR_EPOCH_PLOTMANAGEMENT_MAINTAIN_PRICE", [_amount] call BIS_fnc_numberText, _itemText];
+
+	[_type,_amount,_itemText,_wealth]
+};
+
+_maintain = {
+	private ["_requirements","_count","_type","_amount","_itemText","_wealth","_success","_message1","_message2","_ctrl"];
+
+	_count = count (_this select 0);
+	_requirements = _count call _req;
+
+	_type = _requirements select 0;
+	_amount = _requirements select 1;
+	_itemText = _requirements select 2;
+	_wealth = _requirements select 3;
+	
+	_success = if (Z_SingleCurrency) then {_amount <= _wealth} else {[[[_type, _amount]],0] call epoch_returnChange};
+	
+	if (_success) then {
+		player playActionNow "Medic";
+		[player,DZE_maintainRange,true,(getPosATL player)] spawn player_alertZombies;
+
+		if (Z_SingleCurrency) then {
+			player setVariable[Z_MoneyVariable,(_wealth - _amount),true];
+			call player_forceSave;
+		};
+
+		PVDZE_maintainArea = [player,1,_this select 0];
+		publicVariableServer "PVDZE_maintainArea";
+
+		systemChat format[localize "STR_EPOCH_ACTIONS_4", _count];
+		_message1 = format [localize "STR_EPOCH_PLOTMANAGEMENT_OBJECTS_MAINTAINED_SUCCESS", _count, [_amount] call BIS_fnc_numberText, _itemText];
+		_message2 = " ";
 		if (DZE_permanentPlot) then {
 			_ctrl = (uiNamespace getVariable "PlotManagement") displayCtrl 7012;
 			_ctrl ctrlSetText _message1;
 			_ctrl = (uiNamespace getVariable "PlotManagement") displayCtrl 7013;
 			_ctrl ctrlSetText _message2;
 		} else {
-			_message2 call dayz_rollingMessages;
+			_message1 call dayz_rollingMessages;
+		};
+	} else {
+		_message1 = format[localize "STR_EPOCH_PLOTMANAGEMENT_OBJECTS_MAINTAINED_FAILED", _count, [_amount] call BIS_fnc_numberText, _itemText];
+		_message2 = " ";
+		if (DZE_permanentPlot) then {
+			_ctrl = (uiNamespace getVariable "PlotManagement") displayCtrl 7012;
+			_ctrl ctrlSetText _message1;
+			_ctrl = (uiNamespace getVariable "PlotManagement") displayCtrl 7013;
+			_ctrl ctrlSetText _message2;
+		} else {
 			_message1 call dayz_rollingMessages;
 		};
 	};
 };
 
+{
+    if (damage _x >= DZE_DamageBeforeMaint) then {
+		_objectUID = _x getVariable ["ObjectUID","0"];
+		_objectID = _x getVariable ["ObjectID","0"];
+		_objects_filtered set [count _objects_filtered, [_x, _objectID, _objectUID]];
+		_count = _count + 1;
+   };
+} count _objects;
+
+_option = if (typeName _this == "ARRAY") then {_this select 3} else {_this};
+
+switch _option do {
+	case "maintain": {
+		if (_count != 0) then {
+			[_objects_filtered] call _maintain;
+		} else {
+			systemChat localize "STR_EPOCH_PLOTMANAGEMENT_MAINTAIN_NONE";
+		};
+	};
+	case "preview": {
+		if (_count == 0) then {
+			_message1 = localize "STR_EPOCH_PLOTMANAGEMENT_MAINTAIN_NONE";
+			if (DZE_permanentPlot) then {
+				_ctrl = (uiNamespace getVariable "PlotManagement") displayCtrl 7012;
+				_ctrl ctrlSetText _message1;
+			} else {
+				_message1 call dayz_rollingMessages;
+			};
+		} else {
+			_requirements = _count call _req;
+			_message1 = format [localize "STR_EPOCH_PLOTMANAGEMENT_MAINTAIN_PRICE", _count,[_requirements select 1] call BIS_fnc_numberText,_requirements select 2];
+			if (DZE_permanentPlot) then {
+				_ctrl = (uiNamespace getVariable "PlotManagement") displayCtrl 7012;
+				_ctrl ctrlSetText _message1;
+			} else {
+				_message1 call dayz_rollingMessages;
+			};
+		};
+		_requirements = count _objects call _req;
+		_message2 = format [localize "STR_EPOCH_PLOTMANAGEMENT_MAINTAIN_FORCE",count _objects,[_requirements select 1] call BIS_fnc_numberText,_requirements select 2]; 
+		if (_count != count _objects) then {
+			if (DZE_permanentPlot) then {
+				_ctrl = (uiNamespace getVariable "PlotManagement") displayCtrl 7013;
+				_ctrl ctrlSetText _message2;
+			} else {
+				_message2 call dayz_rollingMessages;
+			};
+		};
+	};
+	case "force": {
+		_count = 0;
+		_objects_filtered = [];
+		{
+			_objectUID = _x getVariable ["ObjectUID","0"];
+			_objectID = _x getVariable ["ObjectID","0"];
+			_objects_filtered set [count _objects_filtered, [_x, _objectID, _objectUID]];
+			_count = _count + 1;
+		} count _objects;
+
+		[_objects_filtered] call _maintain;
+	};
+};
+
 dayz_actionInProgress = false;
 s_player_maintain_area = -1;
+s_player_maintain_area_force = -1;
 s_player_maintain_area_preview = -1;

--- a/SQF/dayz_code/compile/fn_selfActions.sqf
+++ b/SQF/dayz_code/compile/fn_selfActions.sqf
@@ -666,17 +666,18 @@ if (!isNull _cursorTarget && !_inVehicle && !_isPZombie && (player distance _cur
 		} else {
 			if (s_player_maintain_area < 0) then {
 				s_player_maintain_area = player addAction [format["<t color='#ff0000'>%1</t>",localize "STR_EPOCH_ACTIONS_MAINTAREA"], "\z\addons\dayz_code\actions\plotManagement\maintain_area.sqf", "maintain", 5, false];
+				s_player_maintain_area_force = player addAction [format["<t color='#ff0000'>%1</t>",localize "STR_EPOCH_ACTIONS_FORCE_MAINTAREA"], "\z\addons\dayz_code\actions\plotManagement\maintain_area.sqf", "force", 5, false];
 				s_player_maintain_area_preview = player addAction [format["<t color='#ff0000'>%1</t>",localize "STR_EPOCH_ACTIONS_MAINTPREV"], "\z\addons\dayz_code\actions\plotManagement\maintain_area.sqf", "preview", 5, false];
 			};
 		};
 		_PlotsmarkersNear = count (_cursorTarget nearEntities ["Land_coneLight", DZE_PlotPole select 0]);
 		if (s_player_plot_boundary_on < 0) then {
-			If (_PlotsmarkersNear == 0 ) then{
+			if (_PlotsmarkersNear == 0) then{
 				s_player_plot_boundary_on = player addAction ["Show plot boundary", "\z\addons\dayz_code\actions\A_Plot_for_Life\object_showPlotRadius.sqf", "", 1, false];
 			};
 		 };	
 		 if (s_player_plot_boundary_off < 0) then {
-			If (_PlotsmarkersNear > 0 ) then{
+			if (_PlotsmarkersNear > 0) then{
 				s_player_plot_boundary_off = player addAction ["Remove plot boundary", "\z\addons\dayz_code\actions\A_Plot_for_Life\object_removePlotRadius.sqf", "", 1, false];
 			};
 		};
@@ -695,6 +696,8 @@ if (!isNull _cursorTarget && !_inVehicle && !_isPZombie && (player distance _cur
 		s_player_plotManagement = -1;
 		player removeAction s_player_maintain_area;
 		s_player_maintain_area = -1;
+		player removeAction s_player_maintain_area_force;
+		s_player_maintain_area_force = -1;
 		player removeAction s_player_maintain_area_preview;
 		s_player_maintain_area_preview = -1;
 		player removeAction s_player_plot_boundary_on;
@@ -1185,6 +1188,8 @@ if (!isNull _cursorTarget && !_inVehicle && !_isPZombie && (player distance _cur
 	s_player_SurrenderedGear = -1;
 	player removeAction s_player_maintain_area;
 	s_player_maintain_area = -1;
+	player removeAction s_player_maintain_area_force;
+	s_player_maintain_area_force = -1;
 	player removeAction s_player_maintain_area_preview;
 	s_player_maintain_area_preview = -1;	
 	player removeAction s_player_tamedog;

--- a/SQF/dayz_code/init/variables.sqf
+++ b/SQF/dayz_code/init/variables.sqf
@@ -234,6 +234,7 @@ dayz_resetSelfActions = {
 	s_halo_action = -1;
 	s_player_SurrenderedGear = -1;
 	s_player_maintain_area = -1;
+	s_player_maintain_area_force = -1;
 	s_player_maintain_area_preview = -1;
 	s_player_heli_lift = -1;
 	s_player_heli_detach = -1;

--- a/SQF/dayz_code/stringtable.xml
+++ b/SQF/dayz_code/stringtable.xml
@@ -13231,6 +13231,9 @@
 			<French>Maintenir la zone</French>
 			<Czech>Údržba oblasti</Czech>
 		</Key>
+		<Key ID="STR_EPOCH_ACTIONS_FORCE_MAINTAREA">
+			<English>Force Maintain Area</English>
+		</Key>
 		<Key ID="STR_EPOCH_ACTIONS_MAINTPREV">
 			<English>Maintain Area Preview</English>
 			<German>Kostenvoranschlag für Instandhaltung</German>
@@ -13254,7 +13257,6 @@
 			<English>Hotwire %1</English>
 			<German>%1 kurzschliessen</German>
 			<Russian>Угнать %1</Russian>
-			<Dutch>Hotwire %1</Dutch>
 			<French>Démarrer avec les fils %1</French>
 			<Czech>Pokusit se Dostat do Vozidla %1</Czech>
 		</Key>
@@ -13346,6 +13348,9 @@
 			<Dutch>Onderhoud</Dutch>
 			<French>Maintenir</French>
 			<Czech>Opravit</Czech>
+		</Key>
+		<Key ID="STR_EPOCH_ACTIONS_MAINTAIN_FORCE">
+			<English>Force Maintain</English>
 		</Key>
 		<Key ID="STR_EPOCH_ACTIONS_GENERATOR1">
 			<English>Stop Generator</English>
@@ -15011,36 +15016,28 @@
 		
 		<!-- PLOT MANAGEMENT BELOW -->
 		
-		<Key ID="STR_EPOCH_PLOTMANAGEMENT_MAINTAIN_OBJECTS">
-			<English>Objects to maintain: %1</English>
+		<Key ID="STR_EPOCH_PLOTMANAGEMENT_MAINTAIN_NONE"> 
+			<English>Objects to maintain: 0, No maintenance required.</English>
 		</Key>
-		<Key ID="STR_EPOCH_PLOTMANAGEMENT_MAINTAIN_PRICE">
-			<English>Price to maintain: %1 %2</English>
+		<Key ID="STR_EPOCH_PLOTMANAGEMENT_MAINTAIN_PRICE"> 
+			<English>Price to maintain %1 objects: %2 %3</English>
 		</Key>
-		<Key ID="STR_EPOCH_PLOTMANAGEMENT_NO_MONEY_NEEDED">
-			<English>No maintenance needed.</English>
-			<Russian>Деньги не требуются.</Russian>
+		<Key ID="STR_EPOCH_PLOTMANAGEMENT_OBJECTS_MAINTAINED_SUCCESS"> 
+			<English>Success! %1 objects maintained for %2 %3.</English>
 		</Key>
-		<Key ID="STR_EPOCH_PLOTMANAGEMENT_OBJECTS_MAINTAINED_SUCCESS">
-			<English>SUCCESS: Objects maintained: %1</English>
+		<Key ID="STR_EPOCH_PLOTMANAGEMENT_MAINTAIN_FORCE"> 
+			<English>Price to force maintain %1 objects: %2 %3.</English>
 		</Key>
-		<Key ID="STR_EPOCH_PLOTMANAGEMENT_PRICE_MAINTAINED_SUCCESS">
-			<English>SUCCESS: Maintenance cost: %1 %2!</English>
-		</Key>
-		<Key ID="STR_EPOCH_PLOTMANAGEMENT_OBJECTS_MAINTAINED_FAILED">
-			<English>FAILED: Objects maintained: 0</English>
-		</Key>
-		<Key ID="STR_EPOCH_PLOTMANAGEMENT_MONEY_NEEDED_FAILED">
-			<English>FAILED: Money needed: %1 %2!</English>
-			<Russian>ОШИБКА: Требуется денег: %1 %2!</Russian>
+		<Key ID="STR_EPOCH_PLOTMANAGEMENT_OBJECTS_MAINTAINED_FAILED"> 
+			<English>Failed to maintain %1 objects. You need %2 %3.</English>
 		</Key>
 		<Key ID="STR_EPOCH_PLOTMANAGEMENT_ADDFRIEND_ALREADYONTHELIST">
-			<English>That user is already on the list</English>
+			<English>That user is already on the list.</English>
 			<Russian>Уже в списке друзей</Russian>
 			<German>Schon auf der Liste</German>
 		</Key>
 		<Key ID="STR_EPOCH_PLOTMANAGEMENT_ADDFRIEND_FRIENDLIMIT">
-			<English>Only %1 friends are allowed</English>
+			<English>Only %1 friends are allowed.</English>
 			<Russian>Можно добавить друзей: %1</Russian>
 			<German>Nur %1 Freunde erlaubt</German>
 		</Key>
@@ -15055,7 +15052,6 @@
 		</Key>
 		<Key ID="STR_EPOCH_NAME">
 			<English>Name</English>
-			<German>Name</German>
 			<Russian>Имя</Russian>
 			<Italian>Nome</Italian>
 			<Spanish>Nombrar</Spanish>

--- a/SQF/dayz_server/system/server_monitor.sqf
+++ b/SQF/dayz_server/system/server_monitor.sqf
@@ -92,6 +92,7 @@ diag_log ("HIVE: Streamed " + str(_val) + " objects");
 	_storageMoney = _x select 9;
 
 	//set object to be in maintenance mode
+	_maintenanceMode = false;
 	_maintenanceModeVars = [];
 	
 	_dir = 90;


### PR DESCRIPTION
This replaces the "refresh" menu option with a "force maintain" option.
Allows you to maintain the base even if it doesn't need it to either get
all your items in sync or if you are going away or similar.

Tested with:
dze_permanent plot true/false
z_singlecurrency true/false

Also fixes an undefined variable error in system_monitor that was
introduced
https://github.com/EpochModTeam/DayZ-Epoch/commit/8f58baf3f286454a9f398517dc4f1980bd4d5c8e