### PR TITLE
Toggle for salvaging from locked vehicles

### DIFF
--- a/SQF/dayz_code/actions/repair_vehicle.sqf
+++ b/SQF/dayz_code/actions/repair_vehicle.sqf
@@ -35,8 +35,7 @@ _hitpoints = _vehicle call vehicle_getHitpoints;
 
 } forEach _hitpoints;
 
-if (count _hitpoints > 0 ) then {
-	//ArmA OA String
+if (count _hitpoints > 0) then {
 	_cancel = dayz_myCursorTarget addAction [localize "str_action_cancel_action", "\z\addons\dayz_code\actions\repair_cancel.sqf","repair", 0, true, false];
 	s_player_repairActions set [count s_player_repairActions,_cancel];
 	s_player_repair_crtl = 1;

--- a/SQF/dayz_code/actions/salvage_vehicle.sqf
+++ b/SQF/dayz_code/actions/salvage_vehicle.sqf
@@ -1,9 +1,7 @@
 private ["_part","_color","_vehicle","_PlayerNear","_hitpoints","_isATV","_is6WheelType","_HasNoGlassKind",
-"_6WheelTypeArray","_NoGlassArray","_NoExtraWheelsArray","_RemovedPartsArray","_damage","_cmpt","_configVeh","_damagePercent","_string","_handle","_cancel","_type","_isBicycle"];
+"_6WheelTypeArray","_NoGlassArray","_NoExtraWheelsArray","_RemovedPartsArray","_damage","_cmpt","_configVeh","_damagePercent","_string","_handle","_cancel","_type"];
 
 _vehicle = _this select 3;
-_isBicycle = _vehicle isKindOf "Bicycle";
-if (_isBicycle) exitWith {}; // No salvage for now. Bicycle wheels should not give full size tires. Also model does not update to show removed wheels.
 {dayz_myCursorTarget removeAction _x} count s_player_repairActions;s_player_repairActions = [];
 
 _PlayerNear = {isPlayer _x} count ((getPosATL _vehicle) nearEntities ["CAManBase", 10]) > 1;
@@ -16,7 +14,7 @@ _type = typeOf _vehicle;
 _isATV = _type in ["ATV_US_EP1","ATV_CZ_EP1"];
 _is6WheelType = false;
 {if (_type isKindOf _x) exitWith {_is6WheelType = true;};} count ["Kamaz_Base","MTVR","Ural_Base","Ural_Base_withTurret","V3S_Base"];
-_HasNoGlassKind = (_vehicle isKindOf "Motorcycle") or _isBicycle;
+_HasNoGlassKind = (_vehicle isKindOf "Motorcycle");
 
 _6WheelTypeArray = ["HitLMWheel","HitRMWheel"];
 _NoGlassArray = ["HitGlass1","HitGlass2","HitGlass3","HitGlass4","HitGlass5","HitGlass6","HitLGlass","HitRGlass"];
@@ -31,7 +29,7 @@ if (_vehicle isKindOf "tractor") then {
 	_hitpoints = _hitpoints - ["motor","HitLFWheel","HitRFWheel","HitLBWheel","HitRBWheel","HitLF2Wheel","HitRF2Wheel","HitLMWheel","HitRMWheel"];
 };
 
-if (_isBicycle or (_vehicle isKindOf "Motocycle")) then {
+if (_vehicle isKindOf "Motocycle") then {
 	_hitpoints = _hitpoints - ["HitEngine","HitFuel"];
 };
 
@@ -57,7 +55,7 @@ if (_is6WheelType) then {
 
 		//get every damaged part no matter how tiny damage is!
 		_damagePercent = str(round(_damage * 100))+"% Damage";
-		if (_damage < 1 && {_damage > 0}) then {
+		if (_damage < 1) then {
 			if ((_damage >= 0) and (_damage <= 0.25)) then {_color = "color='#00ff00'";}; //green
 			if ((_damage >= 0.26) and (_damage <= 0.50)) then {_color = "color='#ffff00'";}; //yellow
 			if ((_damage >= 0.51) and (_damage <= 0.75)) then {_color = "color='#ff8800'";}; //orange
@@ -71,7 +69,6 @@ if (_is6WheelType) then {
 } forEach _hitpoints;
 
 if (count _hitpoints > 0 ) then {
-	//ArmA OA String
 	_cancel = dayz_myCursorTarget addAction [localize "str_action_cancel_action", "\z\addons\dayz_code\actions\repair_cancel.sqf","repair", 0, true, false];
 	s_player_repairActions set [count s_player_repairActions,_cancel];
 	s_player_repair_crtl = 1;

--- a/SQF/dayz_code/actions/salvage_vehicle.sqf
+++ b/SQF/dayz_code/actions/salvage_vehicle.sqf
@@ -55,7 +55,7 @@ if (_is6WheelType) then {
 
 		//get every damaged part no matter how tiny damage is!
 		_damagePercent = str(round(_damage * 100))+"% Damage";
-		if (_damage < 1) then {
+		if (_damage < 1 && {_damage > 0}) then {
 			if ((_damage >= 0) and (_damage <= 0.25)) then {_color = "color='#00ff00'";}; //green
 			if ((_damage >= 0.26) and (_damage <= 0.50)) then {_color = "color='#ffff00'";}; //yellow
 			if ((_damage >= 0.51) and (_damage <= 0.75)) then {_color = "color='#ff8800'";}; //orange

--- a/SQF/dayz_code/compile/fn_selfActions.sqf
+++ b/SQF/dayz_code/compile/fn_selfActions.sqf
@@ -554,7 +554,7 @@ if (!isNull _cursorTarget && !_inVehicle && !_isPZombie && (player distance _cur
 			dayz_myCursorTarget = _cursorTarget;
 			_menu = dayz_myCursorTarget addAction [localize "str_actions_repairveh", "\z\addons\dayz_code\actions\repair_vehicle.sqf",_cursorTarget, 0, true, false];
 			if (!_isBicycle) then {
-				if (!DZE_salvagedLocked) then {
+				if (!DZE_salvageLocked) then {
 					if (!locked _cursorTarget) then {
 						_menu1 = dayz_myCursorTarget addAction [localize "str_actions_salvageveh", "\z\addons\dayz_code\actions\salvage_vehicle.sqf",_cursorTarget, 0, true, false];
 						s_player_repairActions set [count s_player_repairActions,_menu1];

--- a/SQF/dayz_code/compile/fn_selfActions.sqf
+++ b/SQF/dayz_code/compile/fn_selfActions.sqf
@@ -552,10 +552,19 @@ if (!isNull _cursorTarget && !_inVehicle && !_isPZombie && (player distance _cur
 	if (_isVehicle && {!_isMan} && {dayz_myCursorTarget != _cursorTarget} && {_hasToolbox} && {damage _cursorTarget < 1} && {_typeOfCursorTarget != "M240Nest_DZ"}) then {
 		if (s_player_repair_crtl < 0) then {
 			dayz_myCursorTarget = _cursorTarget;
-			_menu = dayz_myCursorTarget addAction [localize "str_actions_rapairveh", "\z\addons\dayz_code\actions\repair_vehicle.sqf",_cursorTarget, 0, true, false];
-			_menu1 = dayz_myCursorTarget addAction [localize "str_actions_salvageveh", "\z\addons\dayz_code\actions\salvage_vehicle.sqf",_cursorTarget, 0, true, false];
+			_menu = dayz_myCursorTarget addAction [localize "str_actions_repairveh", "\z\addons\dayz_code\actions\repair_vehicle.sqf",_cursorTarget, 0, true, false];
+			if (!_isBicycle) then {
+				if (!DZE_salvagedLocked) then {
+					if (!locked _cursorTarget) then {
+						_menu1 = dayz_myCursorTarget addAction [localize "str_actions_salvageveh", "\z\addons\dayz_code\actions\salvage_vehicle.sqf",_cursorTarget, 0, true, false];
+						s_player_repairActions set [count s_player_repairActions,_menu1];
+					};
+				} else {
+					_menu1 = dayz_myCursorTarget addAction [localize "str_actions_salvageveh", "\z\addons\dayz_code\actions\salvage_vehicle.sqf",_cursorTarget, 0, true, false];
+					s_player_repairActions set [count s_player_repairActions,_menu1];
+				};
+			};
 			s_player_repairActions set [count s_player_repairActions,_menu];
-			s_player_repairActions set [count s_player_repairActions,_menu1];
 			s_player_repair_crtl = 1;
 		} else {
 			{dayz_myCursorTarget removeAction _x} forEach s_player_repairActions;

--- a/SQF/dayz_code/configVariables.sqf
+++ b/SQF/dayz_code/configVariables.sqf
@@ -42,6 +42,7 @@ DZE_SafeZonePosArray = []; //Prevent players in safeZones from being killed if t
 DZE_GemOccurance = [["ItemTopaz",10], ["ItemObsidian",8], ["ItemSapphire",6], ["ItemAmethyst",4], ["ItemEmerald",3], ["ItemCitrine",2], ["ItemRuby",1]]; //Sets how rare each gem is in the order shown when mining (whole numbers only)
 DZE_GodModeBaseExclude = []; //Array of object class names excluded from the god mode bases feature
 DZE_groupManagement = false; //Enable or disable group management. Enabled by default
+DZE_salvagedLocked = false; //Enable or disable salvaging of locked vehicles, useful for stopping griefing on locked vehicles.
 
 // Trader Menu
 dayz_sellDistance_vehicle = 10; // Max distance players can sell land vehicles from at traders

--- a/SQF/dayz_code/configVariables.sqf
+++ b/SQF/dayz_code/configVariables.sqf
@@ -42,7 +42,7 @@ DZE_SafeZonePosArray = []; //Prevent players in safeZones from being killed if t
 DZE_GemOccurance = [["ItemTopaz",10], ["ItemObsidian",8], ["ItemSapphire",6], ["ItemAmethyst",4], ["ItemEmerald",3], ["ItemCitrine",2], ["ItemRuby",1]]; //Sets how rare each gem is in the order shown when mining (whole numbers only)
 DZE_GodModeBaseExclude = []; //Array of object class names excluded from the god mode bases feature
 DZE_groupManagement = false; //Enable or disable group management. Enabled by default
-DZE_salvagedLocked = false; //Enable or disable salvaging of locked vehicles, useful for stopping griefing on locked vehicles.
+DZE_salvageLocked = false; //Enable or disable salvaging of locked vehicles, useful for stopping griefing on locked vehicles.
 
 // Trader Menu
 dayz_sellDistance_vehicle = 10; // Max distance players can sell land vehicles from at traders

--- a/SQF/dayz_code/stringtable.xml
+++ b/SQF/dayz_code/stringtable.xml
@@ -653,7 +653,7 @@
 			<French>Réparer%1 (%2)</French>
 			<Czech>Opravit%1 (%2)</Czech>
 		</Key>
-		<Key ID="str_actions_rapairveh">
+		<Key ID="str_actions_repairveh">
 			<English>Repair Vehicle</English>
 			<Spanish>Reparar Vehículo</Spanish>
 			<Russian>Отремонтировать транспорт</Russian>


### PR DESCRIPTION
This adds the ability to remove salvaging from locked vehicles which helps avoid griefing
Fixes a spelling mistake for a localization string
Makes it possible to salvage 0% damaged items again, this was disabled as per
https://github.com/EpochModTeam/DayZ-Epoch/commit/3292d84b857f307571af9233dcfffe9d59a0b5e9
I've had this running on my server for a year or so with no issues (not that it doesn't affect it, i've just never seen it)
It seems to me it's rather silly you cant salvage undamaged items off a vehicle.
Removes Bicycle checking from salvage_vehicle.sqf and moves it to fn_selfactions to tidy things up, no use having a salvage menu that hangs when you can just not show the salvage menu all together.