### PR TITLE
Adding more loot table for zombies

### DIFF
--- a/SQF/dayz_code/Configs/CfgLoot/CfgLoot.hpp
+++ b/SQF/dayz_code/Configs/CfgLoot/CfgLoot.hpp
@@ -56,6 +56,9 @@ class CfgLoot
 		#include "Groups\Zombies\Police.hpp"
 		#include "Groups\Zombies\Military.hpp"
 		#include "Groups\Zombies\Worker.hpp" //DZE
+		#include "Groups\Zombies\Suit.hpp" //DZE
+		#include "Groups\Zombies\Doctor.hpp" //DZE
+		#include "Groups\Zombies\Pilot.hpp" //DZE
 		
 		#undef DZ_BP_VestPouch
 		#undef DZ_BP_Patrol

--- a/SQF/dayz_code/Configs/CfgLoot/Groups/Zombies/Doctor.hpp
+++ b/SQF/dayz_code/Configs/CfgLoot/Groups/Zombies/Doctor.hpp
@@ -1,0 +1,16 @@
+ZombieDoctor[] =
+{
+	{Loot_MAGAZINE,		5,		ItemMorphine},
+	{Loot_MAGAZINE,		3,		ItemBloodTester},
+	{Loot_MAGAZINE,		5,		ItemHeatPack},
+	{Loot_MAGAZINE,		2,		ItemBloodbagEmpty},
+	{Loot_GROUP,		2,		Antibiotics},
+	{Loot_GROUP,		6,		Bloodbags},
+	{Loot_GROUP,		7,		MedicalLow}
+};
+
+ZombieDoctorViral[] =
+{
+	{Loot_GROUP,		10,		ZombieMedical},
+	{Loot_MAGAZINE,		1,		ItemAntibiotic1}
+};

--- a/SQF/dayz_code/Configs/CfgLoot/Groups/Zombies/Pilot.hpp
+++ b/SQF/dayz_code/Configs/CfgLoot/Groups/Zombies/Pilot.hpp
@@ -1,0 +1,15 @@
+ZombiePilot[] =
+{
+	{Loot_MAGAZINE,		1,		FoodMRE},
+	{Loot_MAGAZINE,		2,		ItemHotwireKit},
+	{Loot_GROUP,		3,		MedicalLow},
+	{Loot_GROUP,		10,		AmmoMilitaryLow},
+	{Loot_GROUP,		2,		AmmoMilitaryHigh},
+	{Loot_GROUP,		2,		Consumable}
+};
+
+ZombiePilotViral[] =
+{
+	{Loot_GROUP,		10,		ZombieMilitary},
+	{Loot_MAGAZINE,		1,		ItemAntibiotic1}
+};

--- a/SQF/dayz_code/Configs/CfgLoot/Groups/Zombies/Suit.hpp
+++ b/SQF/dayz_code/Configs/CfgLoot/Groups/Zombies/Suit.hpp
@@ -1,0 +1,15 @@
+ZombieSuit[] =
+{
+	{Loot_GROUP,		6,		Consumable},
+	{Loot_GROUP,		1,		AmmoCivilian},
+	{Loot_MAGAZINE,		3,		ItemBandage},
+	{Loot_MAGAZINE,		2,		ItemPainkiller},
+	{Loot_MAGAZINE,		2,		ItemAntibacterialWipe},
+	{Loot_MAGAZINE,		3,		ItemDocument}
+};
+
+ZombieSuitViral[] =
+{
+	{Loot_GROUP,		10,		ZombieCivilian},
+	{Loot_MAGAZINE,		1,		ItemAntibiotic1}
+};

--- a/SQF/dayz_code/Configs/CfgVehicles/Zeds/Zeds.hpp
+++ b/SQF/dayz_code/Configs/CfgVehicles/Zeds/Zeds.hpp
@@ -215,7 +215,7 @@ class z_soldier : zZombie_Base {
 
 class z_soldier_pilot : z_soldier {
 	displayName = $STR_ZNAME_PILOT;
-	zombieLoot = ZombieMilitary;
+	zombieLoot = ZombiePilot;
 	model = "\ca\characters_d_BAF\BAF_Pilot_BAF";
 	hiddenSelections[] = {"Camo", "Camo2", "Camo3"};
 	hiddenSelectionsTextures[] = {"\ca\characters_W_baf\data\camo_dpm_co.paa", "\ca\characters_W_baf\data\armour_dpm_co.paa", "\ca\characters_W_baf\data\equip_dpm_co.paa"};
@@ -300,7 +300,7 @@ class z_policeman : zZombie_Base {
 };
 class z_suit1 : zZombie_Base {
 	displayName = $STR_ZNAME_SUIT;
-	zombieLoot = ZombieCivilian;
+	zombieLoot = ZombieSuit;
 	model = "\ca\characters2\civil\Functionary\Functionary";
 	hiddenSelections[] = {"Camo"};
 	hiddenSelectionsTextures[] = {"\ca\characters2\civil\functionary\data\functionary_co.paa"};
@@ -311,7 +311,7 @@ class z_suit1 : zZombie_Base {
 	};
 }; 
 class z_suit2 : z_suit1 {
-	zombieLoot = ZombieCivilian;
+	zombieLoot = ZombieSuit;
 	hiddenSelectionsTextures[] = {"\ca\characters2\civil\functionary\data\functionary2_co.paa"};
 };
 class z_worker1 : zZombie_Base { 
@@ -336,7 +336,7 @@ class z_worker3 : z_worker1 {
 class z_doctor : zZombie_Base { 
 	displayName = $STR_ZNAME_DOCTOR;
 	model = "\ca\characters2\civil\Doctor\Doctor";
-	zombieLoot = MedicalHigh;
+	zombieLoot = ZombieDoctor;
 	hiddenSelections[] = {"Camo"};
 	hiddenSelectionsTextures[] = {"\dayz\textures\clothes\doctor_co.paa"};
 	


### PR DESCRIPTION
Ive added 3 more loot tables for the zombie types z_soldier_pilot, z_suit1 and z_suit2, z_doctor. That gives admins a better way to cusomize the loot table from each zombietyp.