### PR TITLE
Advanced trading bugfix, Snap building typo and snap point fixes

### DIFF
--- a/SQF/dayz_code/Configs/CfgExtra/snappoints.hpp
+++ b/SQF/dayz_code/Configs/CfgExtra/snappoints.hpp
@@ -242,8 +242,8 @@ class SnapBuilding {
 	class Cinder_DZE: FloorsWallsStairs { //All cinder walls and doors
 		points[] = {
 		{0,0,0,"Pivot"},
-		{-2.64, 0, 1.685,"Left"},
-		{2.64, 0, 1.685,"Right"},
+		{-2.64, 0, 0,"Left"},
+		{2.64, 0, 0,"Right"},
 		{0, 0, 3.37042,"Top"}
 		};
 		radius = 10;
@@ -251,8 +251,8 @@ class SnapBuilding {
 	class CinderWall_Preview_DZ: Cinder_DZE {
 		points[] = {
 		{0,0,0,"Pivot"},
-		{-2.64, 0, 0,"Left"},
-		{2.64, 0, 0,"Right"},
+		{-2.64, 0, -0.009,"Left"},
+		{2.64, 0, -0.009,"Right"},
 		{0, 0, 1.685,"Top"},
 		{0,0,-1.685,"Bottom"}
 		};

--- a/SQF/dayz_code/actions/AdvancedTrading/functions/z_at_fillBuyableList.sqf
+++ b/SQF/dayz_code/actions/AdvancedTrading/functions/z_at_fillBuyableList.sqf
@@ -4,13 +4,13 @@ private ["_index","_count","_type","_name","_weapons","_typeOf"];
 _weapons = weapons player;
 _weapons set [count _weapons,dayz_onBack];
 _typeOf = typeOf (unitBackPack player);
-_count = 0;
 
 {
 	_index = lbAdd [Z_AT_BUYABLELIST,  _x select 3];
 	lbSetPicture [Z_AT_BUYABLELIST, _index, _x select 4 ];
 	_name = _x select 0;
 	_type = _x select 1;
+	_count = 0;
 	
 	if (_type in DZE_tradeVehicle) then {
 		_count = { local _x } count (nearestObjects [(getPosATL player), [_name], Z_VehicleDistance]);

--- a/SQF/dayz_code/actions/snap_build.sqf
+++ b/SQF/dayz_code/actions/snap_build.sqf
@@ -203,7 +203,7 @@ fnc_initSnapTutorial = {
 				_bldTxtStringQE = format["<t %1%3%4%5>[Q / E]<t %2>: Rotate object 180 degrees while holding.</t></t><br />",_bldTxtClrO,_bldTxtClrW,_bldTxtSzT,_bldTxtShdw,_bldTxtAlgnL];
 				_bldTxtStringQEF = format["<t %1%3%4%5>[Q / E]<t %2>: Rotate object 45 degrees while dropped or snapped.</t></t><br /><br />",_bldTxtClrO,_bldTxtClrW,_bldTxtSzT,_bldTxtShdw,_bldTxtAlgnL];
 				_bldTxtStringFD = format["<t %1%3%4%5>[F]<t %2>: Drop / Pick up object.</t></t><br />",_bldTxtClrO,_bldTxtClrW,_bldTxtSzT,_bldTxtShdw,_bldTxtAlgnL];
-				_bldTxtStringFS = format["<t %1%3%4%5>[F]<t %2>: Snap /Pick up object.</t></t><br />",_bldTxtClrO,_bldTxtClrW,_bldTxtSzT,_bldTxtShdw,_bldTxtAlgnL];
+				_bldTxtStringFS = format["<t %1%3%4%5>[F]<t %2>: Snap / Pick up object.</t></t><br />",_bldTxtClrO,_bldTxtClrW,_bldTxtSzT,_bldTxtShdw,_bldTxtAlgnL];
 				switch (_bldTxtSwitch) do {
 					case "init": {
 						_bldTxtFinal = _bldTxtStringTitle + _bldTxtStringSD + _bldTxtStringPG + _bldTxtStringAPG + _bldTxtStringCPG + _bldTxtStringQE + _bldTxtStringQEF + _bldTxtStringFD;


### PR DESCRIPTION
Fixes a bug with advanced trading green "you have this item" text in
buyables list, this was showing you had the item when you didn't.
Snap building typo
Snap building snap points for large cinder walls as reported by
@SmokeyBR
https://github.com/EpochModTeam/DayZ-Epoch/issues/1766#issuecomment-248021073