### PR TITLE
Advanced trading fixes, server_handleSafeGear human readibility

### DIFF
--- a/SQF/dayz_code/Configs/CfgExtra/snappoints.hpp
+++ b/SQF/dayz_code/Configs/CfgExtra/snappoints.hpp
@@ -2,7 +2,6 @@
 Created by Raymix
 */
 
-
 class SnapBuilding {
 	//Barriers whitelist
 	class Barrier {
@@ -12,11 +11,14 @@ class SnapBuilding {
 			"Land_HBarrier1_DZ",
 			"Sandbag1_DZ",
 			"BagFenceRound_DZ",
-			"Fort_RazorWire"
+			"Fort_RazorWire",
+			"WoodFloorQuarter_DZ",
+			"WoodFloorHalf_DZ",
+			"WoodFloor_DZ",	
+			"MetalFloor_DZ"
 		};
 		radius = 5;
 	};
-	//snap points
 	class Land_HBarrier5Preview: Barrier{ //fix for broken offsets in ghost
 		points[] = {
 		{0,0,0,"Pivot"},
@@ -242,8 +244,8 @@ class SnapBuilding {
 	class Cinder_DZE: FloorsWallsStairs { //All cinder walls and doors
 		points[] = {
 		{0,0,0,"Pivot"},
-		{-2.64, 0, 0,"Left"},
-		{2.64, 0, 0,"Right"},
+		{-2.64, 0, 1.685,"Left"},
+		{2.64, 0, 1.685,"Right"},
 		{0, 0, 3.37042,"Top"}
 		};
 		radius = 10;
@@ -255,6 +257,22 @@ class SnapBuilding {
 		{2.64, 0, -0.009,"Right"},
 		{0, 0, 1.685,"Top"},
 		{0,0,-1.685,"Bottom"}
+		};
+	};
+	class CinderWallDoorway_Preview_DZ: Cinder_DZE {
+		points[] = {
+		{0,0,0,"Pivot"},
+		{-2.64, 0, 1.685,"Left"},
+		{2.64, 0, 1.685,"Right"},
+		{0, 0, 3.37042,"Top"}
+		};
+	};
+	class CinderWallSmallDoorway_Preview_DZ: Cinder_DZE {
+		points[] = {
+		{0,0,0,"Pivot"},
+		{-2.64, 0, 1.685,"Left"},
+		{2.64, 0, 1.685,"Right"},
+		{0, 0, 3.37042,"Top"}
 		};
 	};
 	class CinderWallDoorway_Preview_DZ: Cinder_DZE {};

--- a/SQF/dayz_code/actions/AdvancedTrading/functions/z_at_buyItems.sqf
+++ b/SQF/dayz_code/actions/AdvancedTrading/functions/z_at_buyItems.sqf
@@ -1,6 +1,4 @@
-private ["_weaponsToBuy","_backpacksToBuy","_toolsToBuy","_sidearmToBuy","_primaryToBuy","_priceToBuy"
-,"_enoughMoney","_myMoney","_canBuy","_moneyInfo","_count","_success","_toolClasses","_itemsToLog"
-,"_tCost","_bTotal","_backpack","_pistolMagsToBuy","_regularMagsToBuy","_hasPrimary","_p","_toolAmounts"];
+private ["_activatingPlayer","_bTotal","_backpack","_backpacksToBuy","_buyVehicle","_buyingType","_canBuy","_count","_dir","_enoughMoney","_hasPrimary","_helipad","_isKeyOK","_item2Add","_itemsToLog","_keyColor","_keyNumber","_keySelected","_location","_moneyInfo","_myMoney","_p","_parentClasses","_part_out","_pistolMagsToBuy","_price","_priceToBuy","_primaryToBuy","_regularMagsToBuy","_sidearmToBuy","_sign","_success","_tCost","_toolAmounts","_toolClasses","_toolsToBuy","_vehiclesToBuy","_weaponsToBuy","_worth"];
 
 if (count Z_BuyingArray < 1) exitWith { systemChat localize "STR_EPOCH_TRADE_BUY_NO_ITEMS"; };
 
@@ -181,7 +179,11 @@ if (_enoughMoney) then {
 			};
 			_bTotal = _bTotal + (_x select 9);
 		} count Z_BuyingArray;
-		systemChat format[localize "STR_EPOCH_TRADE_BUY_IN_BACKPACK",_bTotal];
+		if (_item2Add != "0") then {
+			systemChat format[localize "STR_EPOCH_TRADE_BUY_VEH_IN_BACKPACK",(Z_BuyingArray select 0) select 3];
+		} else {
+			systemChat format[localize "STR_EPOCH_TRADE_BUY_IN_BACKPACK",_bTotal];
+		};
 	};
 
 	if (Z_SellingFrom == 1) then { //vehicle
@@ -203,7 +205,10 @@ if (_enoughMoney) then {
 			};
 			_bTotal = _bTotal + (_x select 9);
 		} count Z_BuyingArray;
-		systemChat format[localize "STR_EPOCH_TRADE_BUY_IN_VEHICLE",_bTotal,typeOf Z_vehicle];
+		if (_item2Add != "0") then {
+		} else {
+			systemChat format[localize "STR_EPOCH_TRADE_BUY_IN_VEHICLE",_bTotal,typeOf Z_vehicle];
+		};
 	};
 
 	if (Z_SellingFrom == 2) then { //gear
@@ -239,7 +244,11 @@ if (_enoughMoney) then {
 			};
 			_bTotal = _bTotal + (_x select 9);
 		} count Z_BuyingArray;
-		systemChat format[localize "STR_EPOCH_TRADE_BUY_IN_GEAR",_bTotal];
+		if (_item2Add != "0") then {
+			systemChat format[localize "STR_EPOCH_TRADE_BUY_VEH_IN_GEAR",(Z_BuyingArray select 0) select 3];
+		} else {
+			systemChat format[localize "STR_EPOCH_TRADE_BUY_IN_GEAR",_bTotal];
+		};
 	};
 	if (!Z_SingleCurrency) then {
 		_success = [player,_priceToBuy,_moneyInfo,false,0] call Z_payDefault;

--- a/SQF/dayz_code/actions/AdvancedTrading/functions/z_at_buyItems.sqf
+++ b/SQF/dayz_code/actions/AdvancedTrading/functions/z_at_buyItems.sqf
@@ -206,6 +206,7 @@ if (_enoughMoney) then {
 			_bTotal = _bTotal + (_x select 9);
 		} count Z_BuyingArray;
 		if (_item2Add != "0") then {
+			systemChat format[localize "STR_EPOCH_TRADE_BUY_VEH_IN_VEHICLE",(Z_BuyingArray select 0) select 3,typeOf (Z_vehicle)];
 		} else {
 			systemChat format[localize "STR_EPOCH_TRADE_BUY_IN_VEHICLE",_bTotal,typeOf Z_vehicle];
 		};

--- a/SQF/dayz_code/actions/AdvancedTrading/functions/z_at_canAfford.sqf
+++ b/SQF/dayz_code/actions/AdvancedTrading/functions/z_at_canAfford.sqf
@@ -1,4 +1,4 @@
-private ["_worth","_total_currency","_return","_part","_totalToPay","_inventoryMoney","_backpackMoney","_kinds","_amounts","_vehicleMoney"];
+private ["_amounts","_backpackMoney","_backpackPlayer","_counter","_findGem","_forEachIndex","_inventoryMoney","_kinds","_mags","_part","_return","_totalToPay","_total_currency","_vehicleMoney","_worth"];
 
 _totalToPay = _this;
 _return = [false, [], [], [], 0];
@@ -45,7 +45,7 @@ if (Z_AllowTakingMoneyFromBackpack) then {
 				if (_findGem >= 0) then {
 					_worth = DZE_GemWorthList select _findGem;
 					_total_currency = _total_currency + (_worth * (_amounts select _forEachIndex));
-					_counter = 0 ;
+					_counter = 0;
 					while {_counter < (_amounts select _forEachIndex)} do {
 					  _backpackMoney set [count(_backpackMoney),_x];
 					  _counter = _counter + 1;
@@ -68,7 +68,7 @@ if (Z_AllowTakingMoneyFromVehicle) then {
 			_worth =  (_part >> "worth");
 			if isNumber (_worth) then {
 				_total_currency = _total_currency + (getNumber(_worth) * (_amounts select _forEachIndex));
-				_counter = 0 ;
+				_counter = 0;
 				while {_counter < (_amounts select _forEachIndex)} do {
 					_vehicleMoney set [count(_vehicleMoney),_x];
 					_counter = _counter + 1;
@@ -80,7 +80,7 @@ if (Z_AllowTakingMoneyFromVehicle) then {
 					_total_currency = _total_currency + (_worth * (_amounts select _forEachIndex));
 					_counter = 0 ;
 					while {_counter < (_amounts select _forEachIndex)} do {
-					  _backpackMoney set [count(_backpackMoney),_x];
+					  _vehicleMoney set [count(_vehicleMoney),_x];
 					  _counter = _counter + 1;
 					};
 				};

--- a/SQF/dayz_code/actions/AdvancedTrading/functions/z_at_changeBuySell.sqf
+++ b/SQF/dayz_code/actions/AdvancedTrading/functions/z_at_changeBuySell.sqf
@@ -1,6 +1,6 @@
 #include "defines.hpp"
 
-Z_Selling = !Z_Selling;	
+Z_Selling = !Z_Selling;
 if (Z_Selling) then {
 	(findDisplay Z_AT_DIALOGWINDOW displayCtrl Z_AT_SELLBUYTOGGLE) ctrlSetText localize "STR_EPOCH_PLAYER_291";
 	(findDisplay Z_AT_DIALOGWINDOW displayCtrl Z_AT_FILTERBUTTON) ctrlSetText localize "STR_UI_FILTER";

--- a/SQF/dayz_code/actions/AdvancedTrading/functions/z_at_fillBuyableList.sqf
+++ b/SQF/dayz_code/actions/AdvancedTrading/functions/z_at_fillBuyableList.sqf
@@ -12,8 +12,8 @@ _typeOf = typeOf (unitBackPack player);
 	_type = _x select 1;
 	_count = 0;
 	
-	if (_type in DZE_tradeVehicle) then {
-		_count = { local _x } count (nearestObjects [(getPosATL player), [_name], Z_VehicleDistance]);
+	if (_type in DZE_tradeVehicle && {_name == typeOf (DZE_myVehicle)} && {local DZE_myVehicle} && {alive DZE_myVehicle}) then {
+		_count = { (local _x && _x == DZE_myVehicle) } count (nearestObjects [(getPosATL player), [_name], Z_VehicleDistance]);
 	};
 
 	if (_type == "trade_items") then {

--- a/SQF/dayz_code/actions/AdvancedTrading/functions/z_at_fillBuyableList.sqf
+++ b/SQF/dayz_code/actions/AdvancedTrading/functions/z_at_fillBuyableList.sqf
@@ -15,7 +15,6 @@ _typeOf = typeOf (unitBackPack player);
 	if (_type in DZE_tradeVehicle && {_name == typeOf (DZE_myVehicle)} && {local DZE_myVehicle} && {alive DZE_myVehicle}) then {
 		_count = { (local _x && _x == DZE_myVehicle) } count (nearestObjects [(getPosATL player), [_name], Z_VehicleDistance]);
 	};
-
 	if (_type == "trade_items") then {
 		{
 			if (isText(configFile >> "CfgWeapons" >> _x >> "Attachments" >> _name) or _name in getArray (configFile >> "CfgWeapons" >> _x >> "magazines")) then {

--- a/SQF/dayz_code/actions/AdvancedTrading/functions/z_at_logTrade.sqf
+++ b/SQF/dayz_code/actions/AdvancedTrading/functions/z_at_logTrade.sqf
@@ -18,15 +18,15 @@ _Z_logTrade = {
 	// Log to client RPT
 	if (Z_SingleCurrency) then {
 		if (_buyOrSell == "buy") then {
-			diag_log format["%5: Bought %4 x %1 into %7 at %2 for %3x%6",_className,inTraderCity,_price,_quantity,localize "STR_EPOCH_PLAYER_289",_currency,_container];
+			diag_log format["%5: Purchased %4x %1 into %7 at %2 for %3x%6",_className,inTraderCity,_price,_quantity,localize "STR_EPOCH_PLAYER_289",_currency,_container];
 		} else {
-			diag_log format["%5: Sold %4 x %1 from %7 at %2 for %3x%6",_className,inTraderCity,_price,_quantity,localize "STR_EPOCH_PLAYER_289",_currency,_container];
+			diag_log format["%5: Sold %4x %1 from %7 at %2 for %3x%6",_className,inTraderCity,_price,_quantity,localize "STR_EPOCH_PLAYER_289",_currency,_container];
 		};
 	} else {
 		if (_buyOrSell == "buy") then {
-			diag_log format["%5: Bought %4 x %1 into %7 at %2 for %3",_className,inTraderCity,_tCost,_quantity,localize "STR_EPOCH_PLAYER_289",_currency,_container];
+			diag_log format["%5: Purchased %4x %1 into %7 at %2 for %3",_className,inTraderCity,_tCost,_quantity,localize "STR_EPOCH_PLAYER_289",_currency,_container];
 		} else {
-			diag_log format["%5: Sold %4 x %1 from %7 at %2 for %3",_className,inTraderCity,_tCost,_quantity,localize "STR_EPOCH_PLAYER_289",_currency,_container];
+			diag_log format["%5: Sold %4x %1 from %7 at %2 for %3",_className,inTraderCity,_tCost,_quantity,localize "STR_EPOCH_PLAYER_289",_currency,_container];
 		};
 	};	
 

--- a/SQF/dayz_code/actions/AdvancedTrading/functions/z_at_payDefault.sqf
+++ b/SQF/dayz_code/actions/AdvancedTrading/functions/z_at_payDefault.sqf
@@ -12,16 +12,16 @@ _moneyInVehicle = _moneyInfo select 3;
 
 if (!_justChecking) then {
 	{
-	  _nil = [player, _x , 1] call BIS_fnc_invRemove;
+		_nil = [player, _x , 1] call BIS_fnc_invRemove;
 	} count _moneyInGear;
 	
 	_moneyInGear = []; // Clear since money is removed now
 
 	if (count _moneyInBackpack > 0) then {
-	  _nil = [unitBackpack _player, _moneyInBackpack, [], []] call ZUPA_fnc_removeWeaponsAndMagazinesCargo;
+		_nil = [unitBackpack _player, _moneyInBackpack, [], []] call ZUPA_fnc_removeWeaponsAndMagazinesCargo;
 	};
 	if (!isNull Z_vehicle && count _moneyInVehicle > 0) then {
-	  _nil = [Z_vehicle, _moneyInVehicle, [], []] call ZUPA_fnc_removeWeaponsAndMagazinesCargo;
+		_nil = [Z_vehicle, _moneyInVehicle, [], []] call ZUPA_fnc_removeWeaponsAndMagazinesCargo;
 	};
 };
 

--- a/SQF/dayz_code/actions/AdvancedTrading/init.sqf
+++ b/SQF/dayz_code/actions/AdvancedTrading/init.sqf
@@ -111,3 +111,4 @@ createDialog "AdvancedTrading";
 (findDisplay Z_AT_DIALOGWINDOW displayCtrl Z_AT_DETAILSTEXT) ctrlSetText "   " + localize "STR_EPOCH_TRADE_DETAILS";
 
 call Z_ChangeBuySell;
+false call Z_checkCloseVehicle; // set up vehicle for removing currency from it, otherwise you need to click vehicle before currency will be removed.

--- a/SQF/dayz_code/stringtable.xml
+++ b/SQF/dayz_code/stringtable.xml
@@ -15076,6 +15076,15 @@
 			<English>Purchased %1 items into your gear</English>
 			<German>Du hast %1 Gegenstände in deine Ausrüstung gekauft.</German>	
 		</Key>
+		<Key ID="STR_EPOCH_TRADE_BUY_VEH_IN_BACKPACK">
+			<English>You purchased a %1, the key has been added into your backpack.</English>
+		</Key>
+		<Key ID="STR_EPOCH_TRADE_BUY_VEH_IN_VEHICLE">
+			<English>You purchased a %1, the key has been added into your %2.</English>
+		</Key>
+		<Key ID="STR_EPOCH_TRADE_BUY_VEH_IN_GEAR">
+			<English>You purchased a %1, the key has been added to your toolbelt.</English>
+		</Key>		
 		<Key ID="STR_EPOCH_TRADE_SELL_IN_BACKPACK">
 			<English>Sold %1 items from your backpack</English>
 			<German>Du hast %1 Gegenstände aus deinem Rucksack verkauft.</German>	

--- a/SQF/dayz_server/compile/server_tradeObject.sqf
+++ b/SQF/dayz_server/compile/server_tradeObject.sqf
@@ -1,12 +1,16 @@
-private ["_player","_PUID","_name","_traderid","_buyorsell","_data","_result","_key","_outcome","_clientID","_price","_quantity","_container","_return"];
+private ["_player","_playerUID","_name","_traderid","_buyorsell","_data","_result","_key","_outcome","_clientID","_price","_quantity","_container","_return"];
 
 _player =		_this select 0;
 _traderID = 	_this select 1;
 _buyorsell = 	_this select 2;	//0 > Buy // 1 > Sell
 _classname =	_this select 3;
 _traderCity = 	_this select 4;
-_currency =	_this select 5;
+_currency =		_this select 5;
 _price =		_this select 6;
+
+_clientID = 	owner _player;
+_playerUID = 	getPlayerUID _player;
+_name = 		if (alive _player) then { name _player; } else { "Dead Player"; };
 
 if (count _this > 7) then {
 	_quantity = _this select 7;
@@ -18,16 +22,12 @@ if (count _this > 7) then {
 	_return = true;
 };
 
-_clientID = 	owner _player;
-
 if (typeName _price  == "SCALAR") then { _price = format ["%1x%2",_price,_currency]; } else { _price = format ["%1",_price]; };
-_name = if (alive _player) then { name _player; } else { "Dead Player"; };
-_PUID = getPlayerUID _player;
 
 if (_buyorsell == 0) then { //Buy
-	diag_log format["%8: %9: %1 (%2) bought %6 x %3 into %7 at %4 for %5", _name, _PUID, _classname, _traderCity, _price, _quantity,_container,localize "STR_EPOCH_PLAYER_289",localize "STR_EPOCH_PLAYER"];
+	diag_log format["%8: %1 (%2) purchased %6x %3 into %7 at %4 for %5", _name, _playerUID, _classname, _traderCity, _price, _quantity,_container,localize "STR_EPOCH_PLAYER_289"];
 } else { //SELL
-	diag_log format["%8: %9: %1 (%2) sold %6 x %3 from %7 at %4 for %5",_name, _PUID, _classname, _traderCity, _price, _quantity,_container,localize "STR_EPOCH_PLAYER_289",localize "STR_EPOCH_PLAYER"];
+	diag_log format["%8: %1 (%2) sold %6x %3 from %7 at %4 for %5",_name, _playerUID, _classname, _traderCity, _price, _quantity,_container,localize "STR_EPOCH_PLAYER_289"];
 };
 
 if (DZE_ConfigTrader) then {


### PR DESCRIPTION
Fixes a few issues and a dupe with advanced trading as well as some localization of where a vehicle key is going.

Z_at_buyItems: Now adds localization for the key getting added to your toolbelt, backpack and vehicle, this stops players thinking they didn't get a key when infact it was added to their backpack/vehicle.

Z_at_canAfford.sqf: This fixes a dupe from a bad copy paste for whomever wrote this script, it was using _backpackMoney in the z_allowTakingMoneyFromVehicle part, changed to the proper variable _vehicleMoney. **This would dupe your currency before**

z_at_fillBuyableList.sqf: this fixes a bug where a vehicle would show green even when it isn't local, just basically added more checking to make sure the vehicle it's making green in the list is a) local, b) alive and that the typeOf == _name.

z_at_logTrade.sqf: fixes some tidyness.

advancedTrading/init.sqf: adds a z_checkCloseVehicle call otherwise even with Z_AllowTakingMoneyFromVehicle = true it will not get currency from your vehicle until you clicked on the "Vehicle" tab.

dayz_server/server_tradeObject.sqf: More tidying as per the z_at_logTrade and removes the useless Player:, as it is obvious a player has bought something not an AI.

dayz_server/server_handleSafeGear.sqf: Makes the diag_log at the end more human readable with GPS coordinates as well as the lock code for the safe or the lockbox.