### PR TITLE
SQL Update fix for MeleeHatchet_DZE -> MeleeHatchet, localization fix

### DIFF
--- a/SQF/dayz_code/stringtable.xml
+++ b/SQF/dayz_code/stringtable.xml
@@ -848,7 +848,7 @@
 			<Czech>Prozkoumat tělo</Czech>
 		</Key>
 		<Key ID="str_actions_delete">
-			<English>Destroy %1</English>
+			<English>Remove %1</English>
 			<German>%1 abbauen</German>
 			<Russian>Уничтожить %1</Russian>
 			<French>Détruire %1</French>

--- a/Server Files/SQL/1.0.6_Updates.sql
+++ b/Server Files/SQL/1.0.6_Updates.sql
@@ -150,6 +150,14 @@ UPDATE character_data SET Inventory = REPLACE(Inventory, '"ItemHatchet_DZE"', '"
 UPDATE object_data SET Inventory = REPLACE(Inventory, '"ItemHatchet_DZE"', '"ItemHatchet"') WHERE INSTR(Inventory, '"ItemHatchet_DZE"') > 0;
 
 -- ----------------------------
+-- MeleeHatchet_DZE was removed because it was identical to MeleeHatchet
+-- ----------------------------
+UPDATE character_data SET Backpack = REPLACE(Backpack, '"MeleeHatchet_DZE"', '"MeleeHatchet"') WHERE INSTR(Backpack, '"MeleeHatchet_DZE"') > 0;
+UPDATE character_data SET Inventory = REPLACE(Inventory, '"MeleeHatchet_DZE"', '"MeleeHatchet"') WHERE INSTR(Inventory, '"MeleeHatchet_DZE"') > 0;
+UPDATE character_data SET CurrentState = REPLACE(CurrentState, '"MeleeHatchet_DZE"', '"MeleeHatchet"') WHERE INSTR(CurrentState, '"MeleeHatchet_DZE"') > 0;
+UPDATE object_data SET Inventory = REPLACE(Inventory, '"MeleeHatchet_DZE"', '"MeleeHatchet"') WHERE INSTR(Inventory, '"MeleeHatchet_DZE"') > 0;
+
+-- ----------------------------
 -- ItemTentOld and ItemTentDomed2 were removed because they were identical to ItemTent and ItemDomeTent
 -- ----------------------------
 UPDATE `Traders_DATA` SET `item` = '["ItemTent",1]' WHERE `item` = '["ItemTentOld",1]';


### PR DESCRIPTION
Makes MeleeHatchet_DZE for converted databases properly get renamed
Changes Destroy to Remove since you're not completely destroying it, maybe we need a different one for modular parts that wont get returned?