### PR TITLE
Fixing string is not displayed correctly

### DIFF
--- a/SQF/dayz_code/Configs/CfgMagazines/Clothing/Clothing.hpp
+++ b/SQF/dayz_code/Configs/CfgMagazines/Clothing/Clothing.hpp
@@ -21,7 +21,7 @@ class SkinBase : CA_Magazine
 		
 		class tearClothes
 		{
-			text = $str_tear_clothes;
+			text = $STR_TEAR_CLOTHES;
 			script = "spawn player_tearClothes;";
 		};
 		class Crafting {

--- a/SQF/dayz_code/stringtable.xml
+++ b/SQF/dayz_code/stringtable.xml
@@ -1357,7 +1357,7 @@
 			<French>Vous pensez que vous avez besoin de ruban adhésif pour réparer la bouteille.</French>
 			<German>Du könntest Klebeband gebrauchen, um die Flasche zu reparieren.</German>
 		</Key>
-		<Key ID="str_tear_clothes">
+		<Key ID="STR_TEAR_CLOTHES">
 			<English>Tear Clothes</English>
 			<German>Kleidung zerreißen</German>
 		</Key>


### PR DESCRIPTION
@oiad for some reason it is case sensitive here. It works only like that, otherwise there will stand $str_tear_clothes as rightclick option.