### PR TITLE
player_upgrade combination addition

### DIFF
--- a/SQF/dayz_code/actions/player_upgrade.sqf
+++ b/SQF/dayz_code/actions/player_upgrade.sqf
@@ -121,6 +121,7 @@ if ((count _upgrade) > 0) then {
 				_objectCharacterID = _combination;
 				
 				format[localize "str_epoch_player_158",_combination,_text] call dayz_rollingMessages;
+				systemChat format[localize "str_epoch_player_158",_combination,_text];
 			} else {	
 				format[localize "str_epoch_player_159",_text] call dayz_rollingMessages;
 			};


### PR DESCRIPTION
Adds systemChat to receive the combination for whatever you upgrade as
well as dayz_rollingMessages.

The same as what modular_build does.