### PR TITLE
Detection of part doesn't work

### DIFF
--- a/SQF/dayz_code/actions/repair_vehicle.sqf
+++ b/SQF/dayz_code/actions/repair_vehicle.sqf
@@ -17,7 +17,7 @@ _hitpoints = _vehicle call vehicle_getHitpoints;
 
 	_configVeh = configFile >> "cfgVehicles" >> "RepairParts" >> _x;
 	_part = getText(_configVeh >> "part");
-	if (isNil "_part") then { _part = "PartGeneric"; };
+	if ((isNil "_part") || (_part == "")) then { _part = "PartGeneric"; };
 
 	// get every damaged part no matter how tiny damage is!
 	_damagePercent = str(round(_damage * 100))+"% Damage";


### PR DESCRIPTION
For tanks and other vehicles not explicitly defined in configs, _part will return with "" using gettext(), evaluating if it is nil doesn't do anything. With this change it will properly allow for repairing tracks on tanks with scrap metal.