### PR TITLE
 Craft with all Dayz_Ignators

### DIFF
--- a/SQF/dayz_code/actions/player_craftItem.sqf
+++ b/SQF/dayz_code/actions/player_craftItem.sqf
@@ -100,6 +100,9 @@ if (_canDo) then {
 			if (_x == "ItemKnife") then {
 				{if (_x in Dayz_Gutting) exitWith {_hastoolweapon = true};} forEach (items player);
 			};
+			if (_x == "ItemMatchbox") then {
+				{if (_x in Dayz_Ignators) exitWith {_hastoolweapon = true};} forEach (items player);
+			};
 			if (!_hastoolweapon) exitWith { _craft_doLoop = false; _missingTools = true; _missing = _x; };
 		} forEach _selectedRecipeTools;
 


### PR DESCRIPTION
Adding the ability to craft with all Dayz_Ignators when dayz_matchboxCount = true; For example crafting a Firebarrel