### PR TITLE
Backwards array call to Z_checkArrayInConfig

### DIFF
--- a/SQF/dayz_code/actions/AdvancedTrading/functions/z_at_getBackpackItems.sqf
+++ b/SQF/dayz_code/actions/AdvancedTrading/functions/z_at_getBackpackItems.sqf
@@ -25,5 +25,5 @@ if (!isNull _backpack) then {
 	_normalMags = _freeSpace select 5;
 	_normalWeaps = _freeSpace select 6;
 
-	[_normalMags,_normalWeaps, typeOf _backpack,[]] call Z_checkArrayInConfig;
+	[_normalWeaps, _normalMags, typeOf _backpack,[]] call Z_checkArrayInConfig;
 };


### PR DESCRIPTION
Z_checkArrayInConfig is expecting weapons in position 0 for _this, all other stuff like get z_at_getGearItems.sqf and z_at_getVehicleItems.sqf passes the weapons array in position 0.