### PR TITLE
Add harder penalties for wrong combination on doors, More spelling mistakes.

### DIFF
--- a/SQF/dayz_code/actions/doorManagement/player_enterCode.sqf
+++ b/SQF/dayz_code/actions/doorManagement/player_enterCode.sqf
@@ -1,10 +1,13 @@
 private "_display";
 
-// Close DoorAccess
 _display = findDisplay 61144;
 _display closeDisplay 2;
+
+if (dayz_lastCodeFail > diag_tickTime) exitWith {
+	format [localize "STR_EPOCH_PLAYER_19_WAIT",round(dayz_lastCodeFail - diag_tickTime)] call dayz_rollingMessages;
+};
+
 if (DZE_doorManagementAllowManualCode) then {
-	//DZE_Lock_Door != (this getvariable['CharacterID','0']);
 	DZE_topCombo = 0;
 	DZE_midCombo = 0;
 	DZE_botCombo = 0;

--- a/SQF/dayz_code/actions/player_destroyTent.sqf
+++ b/SQF/dayz_code/actions/player_destroyTent.sqf
@@ -1,3 +1,5 @@
+private ["_emptycan","_objectID","_objectUID","_obj","_fuelArray","_matchArray","_alreadyDestorying","_randomJerryCan","_fireIntensity","_dis","_sfx"];
+
 //Tent Object
 _obj = _this select 3;
 _objectID = _obj getVariable["ObjectID","0"];

--- a/SQF/dayz_code/actions/player_destroyTent.sqf
+++ b/SQF/dayz_code/actions/player_destroyTent.sqf
@@ -1,4 +1,4 @@
-private ["_cantype","_emptycan","_intensity","_objectID","_objectUID","_obj","_fuelArray","_matchArray","_alreadyDestorying","_randomJerryCan","_fireIntensity","_randomBoxMatches","_qtyRemaining","_dis","_sfx"];
+private ["_cantype","_emptycan","_intensity","_objectID","_objectUID","_obj","_fuelArray","_matchArray","_alreadyDestroying","_randomJerryCan","_fireIntensity","_randomBoxMatches","_qtyRemaining","_dis","_sfx"];
 
 //Tent Object
 _obj = _this select 3;
@@ -34,12 +34,12 @@ player playActionNow "Medic";
 player removeAction s_player_destroytent;
 s_player_destroytent = -1;
 
-//Make sure you can only destory once
-_alreadyDestorying = _obj getVariable["alreadyDestorying",0];
+//Make sure you can only destroy once
+_alreadyDestroying = _obj getVariable["alreadyDestroying",0];
 
-if (_alreadyDestorying == 1) exitWith {localize "str_TentAlreadyLit" call dayz_rollingMessages;};
+if (_alreadyDestroying == 1) exitWith {localize "str_TentAlreadyLit" call dayz_rollingMessages;};
 
-_obj setVariable["alreadyDestorying",1];
+_obj setVariable["alreadyDestroying",1];
 
 //Jerry can system ** Needs redoing
 //Select random can from array
@@ -107,4 +107,4 @@ publicVariable "PVDZ_obj_Fire";
 _obj inflame true;
 //_obj spawn player_fireMonitor;
 
-localize "str_success_tent_destoryed" call dayz_rollingMessages;
+localize "str_success_tent_destroyed" call dayz_rollingMessages;

--- a/SQF/dayz_code/actions/player_destroyTent.sqf
+++ b/SQF/dayz_code/actions/player_destroyTent.sqf
@@ -1,5 +1,3 @@
-private ["_cantype","_emptycan","_intensity","_objectID","_objectUID","_obj","_fuelArray","_matchArray","_alreadyDestroying","_randomJerryCan","_fireIntensity","_randomBoxMatches","_qtyRemaining","_dis","_sfx"];
-
 //Tent Object
 _obj = _this select 3;
 _objectID = _obj getVariable["ObjectID","0"];

--- a/SQF/dayz_code/configVariables.sqf
+++ b/SQF/dayz_code/configVariables.sqf
@@ -94,6 +94,7 @@ DZE_doorManagementMustBeClose = false; //Players must be within 10m of door to b
 DZE_doorManagementAdmins = []; //Array of admin PlayerUIDs. UIDs in this list are able to access every door's management menu and open it.
 DZE_doorManagementAllowManualCode = true; //Allow unlocking doors by manually entering the combination. Setting false requires the use of eye scan for all doors.
 DZE_doorManagementMaxFriends = 10; //Max friends allowed on a door. There is no character limit in the inventory field of the database, but lower values limit the max global setVariable size to improve performance.
+DZE_doorManagementHarderPenalty = true; //Enforce an exponential wait on attempts between unlocking a door from a failed code.
 
 // Group System
 dayz_groupSystem = true; // Enable group system

--- a/SQF/dayz_code/init/variables.sqf
+++ b/SQF/dayz_code/init/variables.sqf
@@ -716,4 +716,5 @@ if (!isDedicated) then {
 	DZE_myVehicle = objNull;
 	dayz_groupNameTags = true;
 	dayz_minusDownTime = 0;
+	dayz_lastCodeFail = 0;
 };

--- a/SQF/dayz_code/stringtable.xml
+++ b/SQF/dayz_code/stringtable.xml
@@ -6598,7 +6598,7 @@
 			<French>Vous ne pouvez pas replier cette tente, elle ne vous appartient pas.</French>
 			<Czech>Tento stan nemůžete zabalit, jelikož není váš.</Czech>
 		</Key>
-		<Key ID="str_success_tent_destoryed">
+		<Key ID="str_success_tent_destroyed">
 			<English>You have successfully destroyed a tent.</English>
 			<German>Du hast das Zelt erfolgreich zerstört.</German>
 			<Russian>Вы успешно уничтожили палатку.</Russian>

--- a/SQF/dayz_code/stringtable.xml
+++ b/SQF/dayz_code/stringtable.xml
@@ -11280,7 +11280,7 @@
 		</Key>
 		<Key ID="STR_EPOCH_PLAYER_19">
 			<English>You entered the wrong code, wait %1 seconds.</English>
-			<German>Es wurde zu oft der falsche Code eingetippt. Du musst nun 10 Sekunden warten</German>
+			<German>Du hast einen falschen Code eingegeben, warte %1 Sekunden.</German>
 			<Russian>Неправильный код введён слишком много раз, подождите 10 секунд</Russian>
 			<Dutch>Je hebt te vaak een foute code ingevoerd. 10 seconden geduld svp.</Dutch>
 			<French>Trop d'erreurs avec le code, patientez 10 secondes</French>
@@ -11288,6 +11288,7 @@
 		</Key>
 		<Key ID="STR_EPOCH_PLAYER_19_WAIT">
 			<English>You must wait another %1 seconds before you can enter another code.</English>
+			<German>Du musst weitere %1 Sekunden warten, bevor du einen anderen Code eingeben kannst.</German>
 		</Key>
 		<Key ID="STR_EPOCH_PLAYER_20">
 			<English>Cannot unlock while another player is nearby.</English>

--- a/SQF/dayz_code/stringtable.xml
+++ b/SQF/dayz_code/stringtable.xml
@@ -11279,12 +11279,15 @@
 			<Czech>Musíte mít syrové maso</Czech>
 		</Key>
 		<Key ID="STR_EPOCH_PLAYER_19">
-			<English>Wrong code entered too many times, wait 10 seconds</English>
+			<English>You entered the wrong code, wait %1 seconds.</English>
 			<German>Es wurde zu oft der falsche Code eingetippt. Du musst nun 10 Sekunden warten</German>
 			<Russian>Неправильный код введён слишком много раз, подождите 10 секунд</Russian>
 			<Dutch>Je hebt te vaak een foute code ingevoerd. 10 seconden geduld svp.</Dutch>
 			<French>Trop d'erreurs avec le code, patientez 10 secondes</French>
 			<Czech>Mnohokrát jsi zadal špatný kód, musíš počkat 10 vteřin</Czech>
+		</Key>
+		<Key ID="STR_EPOCH_PLAYER_19_WAIT">
+			<English>You must wait another %1 seconds before you can enter another code.</English>
 		</Key>
 		<Key ID="STR_EPOCH_PLAYER_20">
 			<English>Cannot unlock while another player is nearby.</English>


### PR DESCRIPTION
This adds a variable (DZE_doorManagementHarderPenalty) to make attempts at code breaking doors harder. This will exponentially increment the time between attempts or if you set it to false will make it 5 seconds between attempts.

Unlike the original (that was useless TBH) this will actually lock out the combo lock UI until the timer is set.

Will reset completely after 120 seconds.

@ebayShopper  Further to commit:
https://github.com/EpochModTeam/DayZ-Epoch/commit/0e938ba8f36b2631b98da1bdbfd3d6d578432110