### PR TITLE
Add logging failed safe/lockbox and door lock/unlock/failed code attempts

### DIFF
--- a/CHANGE LOG 1.0.6.1.txt
+++ b/CHANGE LOG 1.0.6.1.txt
@@ -4,6 +4,7 @@
 [NEW] Building upgrades now source parts from the player's backpack and main inventory. @icomrade
 [NEW] Server owners can configure nutrition system effects with DZE_NutritionDivisor in configVariables.sqf @icomrade
 [NEW] Added back DZE_doorManagementHarderPenalty config variable. Required wait between incorrect entries of manual door codes is multiplied by two each time, starting at five seconds. #1847 @oiad
+[NEW] Added server logging of failed unlock attempts on doors, safes and lockboxes. Also added server logging of all door locking and unlocking. #1853 @oiad
 
 [CHANGED] Turbo and HoldBreath keybindings are now allowed again. @icomrade
 [CHANGED] Removed drink from hands at ponds due to client FPS impact. Players can still fill drinks at ponds by right clicking a container. @ebayShopper

--- a/SQF/dayz_code/Configs/CfgVehicles/DZE/Doors.hpp
+++ b/SQF/dayz_code/Configs/CfgVehicles/DZE/Doors.hpp
@@ -359,21 +359,21 @@ class Land_DZE_WoodDoorLocked: Land_DZE_WoodDoorLocked_Base {
 		{
 			displayName=$STR_EPOCH_DOORS_LOCK;
 			//condition="(this animationPhase ""Open_door"" == 0) and (this animationPhase ""Open_hinge"" == 1)";
-			condition="( !keypadCancel and DZE_Lock_Door == (this getvariable['CharacterID','0'])) and (this animationPhase ""Open_door"" == 0) and (this animationPhase ""Open_hinge"" == 1)";
-			statement="this animate [""Open_hinge"", 0]";
+			condition="(!keypadCancel and DZE_Lock_Door == (this getvariable['CharacterID','0'])) and (this animationPhase ""Open_door"" == 0) and (this animationPhase ""Open_hinge"" == 1)";
+			statement="PVDZE_handleSafeGear = [player,this,4,DZE_Lock_Door];publicVariableServer ""PVDZE_handleSafeGear"";this animate [""Open_latch"", 0]";
 		};
 		class Unlock_Door : Open_Door
 		{
 			displayName=$STR_EPOCH_DOORS_UNLOCK;
 			//condition="(this animationPhase ""Open_door"" == 0) and (this animationPhase ""Open_hinge"" == 0)";
-			condition="( !keypadCancel and DZE_Lock_Door == (this getvariable['CharacterID','0'])) and (this animationPhase ""Open_door"" == 0) and (this animationPhase ""Open_hinge"" == 0)";
+			condition="(!keypadCancel and DZE_Lock_Door == (this getvariable['CharacterID','0'])) and (this animationPhase ""Open_door"" == 0) and (this animationPhase ""Open_hinge"" == 0)";
 			statement="this animate [""Open_hinge"", 1]";
 		};
 		class Unlock_Door_Dialog : Open_Door
 		{
 			displayName=$STR_EPOCH_DOORS_UNLOCK;
 			//condition="(this animationPhase ""Open_door"" == 0) and (this animationPhase ""Open_hinge"" == 0)";
-			condition=" !keypadCancel and DZE_Lock_Door != (this getvariable['CharacterID','0'])";
+			condition="!keypadCancel and DZE_Lock_Door != (this getvariable['CharacterID','0'])";
 			statement="dayz_selectedDoor = this;DZE_topCombo = 0;DZE_midCombo = 0;DZE_botCombo = 0;if(DZE_doorManagement) then {createdialog ""DoorAccess"";} else {createdialog ""ComboLockUI"";};";
 		};
 	};
@@ -459,21 +459,21 @@ class Land_DZE_LargeWoodDoorLocked: Land_DZE_WoodDoorLocked_Base {
 		{
 			displayName=$STR_EPOCH_DOORS_LOCK;
 			//condition="(this animationPhase ""Open_door"" == 0) and (this animationPhase ""Open_hinge"" == 1)";
-			condition="( !keypadCancel and DZE_Lock_Door == (this getvariable['CharacterID','0'])) and (this animationPhase ""Open_door"" == 0) and (this animationPhase ""Open_hinge"" == 1)";
-			statement="this animate [""Open_hinge"", 0]";
+			condition="(!keypadCancel and DZE_Lock_Door == (this getvariable['CharacterID','0'])) and (this animationPhase ""Open_door"" == 0) and (this animationPhase ""Open_hinge"" == 1)";
+			statement="PVDZE_handleSafeGear = [player,this,4,DZE_Lock_Door];publicVariableServer ""PVDZE_handleSafeGear"";this animate [""Open_latch"", 0]";
 		};
 		class Unlock_Door : Open_Door
 		{
 			displayName=$STR_EPOCH_DOORS_UNLOCK;
 			//condition="(this animationPhase ""Open_door"" == 0) and (this animationPhase ""Open_hinge"" == 0)";
-			condition="( !keypadCancel and DZE_Lock_Door == (this getvariable['CharacterID','0'])) and (this animationPhase ""Open_door"" == 0) and (this animationPhase ""Open_hinge"" == 0)";
+			condition="(!keypadCancel and DZE_Lock_Door == (this getvariable['CharacterID','0'])) and (this animationPhase ""Open_door"" == 0) and (this animationPhase ""Open_hinge"" == 0)";
 			statement="this animate [""Open_hinge"", 1]";
 		};
 		class Unlock_Door_Dialog : Open_Door
 		{
 			displayName=$STR_EPOCH_DOORS_UNLOCK;
 			//condition="(this animationPhase ""Open_door"" == 0) and (this animationPhase ""Open_hinge"" == 0)";
-			condition=" !keypadCancel and DZE_Lock_Door != (this getvariable['CharacterID','0'])";
+			condition="!keypadCancel and DZE_Lock_Door != (this getvariable['CharacterID','0'])";
 			statement="dayz_selectedDoor = this;DZE_topCombo = 0;DZE_midCombo = 0;DZE_botCombo = 0;if(DZE_doorManagement) then {createdialog ""DoorAccess"";} else {createdialog ""ComboLockUI"";};";
 		};
 	};
@@ -559,21 +559,21 @@ class Land_DZE_GarageWoodDoorLocked: Land_DZE_WoodDoorLocked_Base {
 		{
 			displayName=$STR_EPOCH_DOORS_LOCK;
 			//condition="(this animationPhase ""Open_door"" == 0) and (this animationPhase ""Open_hinge"" == 1)";
-			condition="( !keypadCancel and DZE_Lock_Door == (this getvariable['CharacterID','0'])) and (this animationPhase ""Open_door"" == 0) and (this animationPhase ""Open_hinge"" == 1)";
-			statement="this animate [""Open_hinge"", 0]";
+			condition="(!keypadCancel and DZE_Lock_Door == (this getvariable['CharacterID','0'])) and (this animationPhase ""Open_door"" == 0) and (this animationPhase ""Open_hinge"" == 1)";
+			statement="PVDZE_handleSafeGear = [player,this,4,DZE_Lock_Door];publicVariableServer ""PVDZE_handleSafeGear"";this animate [""Open_latch"", 0]";
 		};
 		class Unlock_Door : Open_Door
 		{
 			displayName=$STR_EPOCH_DOORS_UNLOCK;
 			//condition="(this animationPhase ""Open_door"" == 0) and (this animationPhase ""Open_hinge"" == 0)";
-			condition="( !keypadCancel and DZE_Lock_Door == (this getvariable['CharacterID','0'])) and (this animationPhase ""Open_door"" == 0) and (this animationPhase ""Open_hinge"" == 0)";
+			condition="(!keypadCancel and DZE_Lock_Door == (this getvariable['CharacterID','0'])) and (this animationPhase ""Open_door"" == 0) and (this animationPhase ""Open_hinge"" == 0)";
 			statement="this animate [""Open_hinge"", 1]";
 		};
 		class Unlock_Door_Dialog : Open_Door
 		{
 			displayName=$STR_EPOCH_DOORS_UNLOCK;
 			//condition="(this animationPhase ""Open_door"" == 0) and (this animationPhase ""Open_hinge"" == 0)";
-			condition=" !keypadCancel and DZE_Lock_Door != (this getvariable['CharacterID','0'])";
+			condition="!keypadCancel and DZE_Lock_Door != (this getvariable['CharacterID','0'])";
 			statement="dayz_selectedDoor = this;DZE_topCombo = 0;DZE_midCombo = 0;DZE_botCombo = 0;if(DZE_doorManagement) then {createdialog ""DoorAccess"";} else {createdialog ""ComboLockUI"";};";
 		};
 	};
@@ -624,21 +624,21 @@ class CinderWallDoorLocked_DZ: CinderWallDoorLocked_DZ_Base {
 		{
 			displayName=$STR_EPOCH_DOORS_LOCK;
 			//condition="(this animationPhase ""Open_door"" == 0) and (this animationPhase ""Open_hinge"" == 1)";
-			condition="( !keypadCancel and DZE_Lock_Door == (this getvariable['CharacterID','0'])) and (this animationPhase ""Open_door"" == 0) and (this animationPhase ""Open_latch"" == 1)";
-			statement="this animate [""Open_latch"", 0]";
+			condition="(!keypadCancel and DZE_Lock_Door == (this getvariable['CharacterID','0'])) and (this animationPhase ""Open_door"" == 0) and (this animationPhase ""Open_latch"" == 1)";
+			statement="PVDZE_handleSafeGear = [player,this,4,DZE_Lock_Door];publicVariableServer ""PVDZE_handleSafeGear"";this animate [""Open_latch"", 0]";
 		};
 		class Unlock_Door : Open_Door
 		{
 			displayName=$STR_EPOCH_DOORS_UNLOCK;
 			//condition="(this animationPhase ""Open_door"" == 0) and (this animationPhase ""Open_hinge"" == 0)";
-			condition="( !keypadCancel and DZE_Lock_Door == (this getvariable['CharacterID','0'])) and (this animationPhase ""Open_door"" == 0) and (this animationPhase ""Open_latch"" == 0)";
+			condition="(!keypadCancel and DZE_Lock_Door == (this getvariable['CharacterID','0'])) and (this animationPhase ""Open_door"" == 0) and (this animationPhase ""Open_latch"" == 0)";
 			statement="this animate [""Open_latch"", 1]";
 		};
 		class Unlock_Door_Dialog : Open_Door
 		{
 			displayName=$STR_EPOCH_DOORS_UNLOCK;
 			//condition="(this animationPhase ""Open_door"" == 0) and (this animationPhase ""Open_hinge"" == 0)";
-			condition=" !keypadCancel and DZE_Lock_Door != (this getvariable['CharacterID','0'])";
+			condition="!keypadCancel and DZE_Lock_Door != (this getvariable['CharacterID','0'])";
 			statement="dayz_selectedDoor = this;DZE_topCombo = 0;DZE_midCombo = 0;DZE_botCombo = 0;if(DZE_doorManagement) then {createdialog ""DoorAccess"";} else {createdialog ""ComboLockUI"";};";
 		};
 	};
@@ -727,21 +727,21 @@ class CinderWallDoorSmallLocked_DZ: CinderWallDoorLocked_DZ_Base {
 		{
 			displayName=$STR_EPOCH_DOORS_LOCK;
 			//condition="(this animationPhase ""Open_door"" == 0) and (this animationPhase ""Open_hinge"" == 1)";
-			condition="( !keypadCancel and DZE_Lock_Door == (this getvariable['CharacterID','0'])) and (this animationPhase ""Open_door"" == 0) and (this animationPhase ""Open_latch"" == 1)";
-			statement="this animate [""Open_latch"", 0]";
+			condition="(!keypadCancel and DZE_Lock_Door == (this getvariable['CharacterID','0'])) and (this animationPhase ""Open_door"" == 0) and (this animationPhase ""Open_latch"" == 1);";
+			statement="PVDZE_handleSafeGear = [player,this,4,DZE_Lock_Door];publicVariableServer ""PVDZE_handleSafeGear"";this animate [""Open_latch"", 0]";
 		};
 		class Unlock_Door : Open_Door
 		{
 			displayName=$STR_EPOCH_DOORS_UNLOCK;
 			//condition="(this animationPhase ""Open_door"" == 0) and (this animationPhase ""Open_hinge"" == 0)";
-			condition="( !keypadCancel and DZE_Lock_Door == (this getvariable['CharacterID','0'])) and (this animationPhase ""Open_door"" == 0) and (this animationPhase ""Open_latch"" == 0)";
+			condition="(!keypadCancel and DZE_Lock_Door == (this getvariable['CharacterID','0'])) and (this animationPhase ""Open_door"" == 0) and (this animationPhase ""Open_latch"" == 0)";
 			statement="this animate [""Open_latch"", 1]";
 		};
 		class Unlock_Door_Dialog : Open_Door
 		{
 			displayName=$STR_EPOCH_DOORS_UNLOCK;
 			//condition="(this animationPhase ""Open_door"" == 0) and (this animationPhase ""Open_hinge"" == 0)";
-			condition=" !keypadCancel and DZE_Lock_Door != (this getvariable['CharacterID','0'])";
+			condition="!keypadCancel and DZE_Lock_Door != (this getvariable['CharacterID','0'])";
 			statement="dayz_selectedDoor = this;DZE_topCombo = 0;DZE_midCombo = 0;DZE_botCombo = 0;if(DZE_doorManagement) then {createdialog ""DoorAccess"";} else {createdialog ""ComboLockUI"";};";
 		};
 	};

--- a/SQF/dayz_code/Configs/CfgVehicles/DZE/Doors.hpp
+++ b/SQF/dayz_code/Configs/CfgVehicles/DZE/Doors.hpp
@@ -360,7 +360,7 @@ class Land_DZE_WoodDoorLocked: Land_DZE_WoodDoorLocked_Base {
 			displayName=$STR_EPOCH_DOORS_LOCK;
 			//condition="(this animationPhase ""Open_door"" == 0) and (this animationPhase ""Open_hinge"" == 1)";
 			condition="(!keypadCancel and DZE_Lock_Door == (this getvariable['CharacterID','0'])) and (this animationPhase ""Open_door"" == 0) and (this animationPhase ""Open_hinge"" == 1)";
-			statement="PVDZE_handleSafeGear = [player,this,4,DZE_Lock_Door];publicVariableServer ""PVDZE_handleSafeGear"";this animate [""Open_hinge"", 0]";
+			statement="PVDZE_handleSafeGear = [player,this,4];publicVariableServer ""PVDZE_handleSafeGear"";this animate [""Open_hinge"", 0]";
 		};
 		class Unlock_Door : Open_Door
 		{
@@ -460,7 +460,7 @@ class Land_DZE_LargeWoodDoorLocked: Land_DZE_WoodDoorLocked_Base {
 			displayName=$STR_EPOCH_DOORS_LOCK;
 			//condition="(this animationPhase ""Open_door"" == 0) and (this animationPhase ""Open_hinge"" == 1)";
 			condition="(!keypadCancel and DZE_Lock_Door == (this getvariable['CharacterID','0'])) and (this animationPhase ""Open_door"" == 0) and (this animationPhase ""Open_hinge"" == 1)";
-			statement="PVDZE_handleSafeGear = [player,this,4,DZE_Lock_Door];publicVariableServer ""PVDZE_handleSafeGear"";this animate [""Open_hinge"", 0]";
+			statement="PVDZE_handleSafeGear = [player,this,4];publicVariableServer ""PVDZE_handleSafeGear"";this animate [""Open_hinge"", 0]";
 		};
 		class Unlock_Door : Open_Door
 		{
@@ -560,7 +560,7 @@ class Land_DZE_GarageWoodDoorLocked: Land_DZE_WoodDoorLocked_Base {
 			displayName=$STR_EPOCH_DOORS_LOCK;
 			//condition="(this animationPhase ""Open_door"" == 0) and (this animationPhase ""Open_hinge"" == 1)";
 			condition="(!keypadCancel and DZE_Lock_Door == (this getvariable['CharacterID','0'])) and (this animationPhase ""Open_door"" == 0) and (this animationPhase ""Open_hinge"" == 1)";
-			statement="PVDZE_handleSafeGear = [player,this,4,DZE_Lock_Door];publicVariableServer ""PVDZE_handleSafeGear"";this animate [""Open_hinge"", 0]";
+			statement="PVDZE_handleSafeGear = [player,this,4];publicVariableServer ""PVDZE_handleSafeGear"";this animate [""Open_hinge"", 0]";
 		};
 		class Unlock_Door : Open_Door
 		{
@@ -625,7 +625,7 @@ class CinderWallDoorLocked_DZ: CinderWallDoorLocked_DZ_Base {
 			displayName=$STR_EPOCH_DOORS_LOCK;
 			//condition="(this animationPhase ""Open_door"" == 0) and (this animationPhase ""Open_hinge"" == 1)";
 			condition="(!keypadCancel and DZE_Lock_Door == (this getvariable['CharacterID','0'])) and (this animationPhase ""Open_door"" == 0) and (this animationPhase ""Open_latch"" == 1)";
-			statement="PVDZE_handleSafeGear = [player,this,4,DZE_Lock_Door];publicVariableServer ""PVDZE_handleSafeGear"";this animate [""Open_latch"", 0]";
+			statement="PVDZE_handleSafeGear = [player,this,4];publicVariableServer ""PVDZE_handleSafeGear"";this animate [""Open_latch"", 0]";
 		};
 		class Unlock_Door : Open_Door
 		{
@@ -728,7 +728,7 @@ class CinderWallDoorSmallLocked_DZ: CinderWallDoorLocked_DZ_Base {
 			displayName=$STR_EPOCH_DOORS_LOCK;
 			//condition="(this animationPhase ""Open_door"" == 0) and (this animationPhase ""Open_hinge"" == 1)";
 			condition="(!keypadCancel and DZE_Lock_Door == (this getvariable['CharacterID','0'])) and (this animationPhase ""Open_door"" == 0) and (this animationPhase ""Open_latch"" == 1);";
-			statement="PVDZE_handleSafeGear = [player,this,4,DZE_Lock_Door];publicVariableServer ""PVDZE_handleSafeGear"";this animate [""Open_latch"", 0]";
+			statement="PVDZE_handleSafeGear = [player,this,4];publicVariableServer ""PVDZE_handleSafeGear"";this animate [""Open_latch"", 0]";
 		};
 		class Unlock_Door : Open_Door
 		{

--- a/SQF/dayz_code/Configs/CfgVehicles/DZE/Doors.hpp
+++ b/SQF/dayz_code/Configs/CfgVehicles/DZE/Doors.hpp
@@ -727,7 +727,7 @@ class CinderWallDoorSmallLocked_DZ: CinderWallDoorLocked_DZ_Base {
 		{
 			displayName=$STR_EPOCH_DOORS_LOCK;
 			//condition="(this animationPhase ""Open_door"" == 0) and (this animationPhase ""Open_hinge"" == 1)";
-			condition="(!keypadCancel and DZE_Lock_Door == (this getvariable['CharacterID','0'])) and (this animationPhase ""Open_door"" == 0) and (this animationPhase ""Open_latch"" == 1);";
+			condition="(!keypadCancel and DZE_Lock_Door == (this getvariable['CharacterID','0'])) and (this animationPhase ""Open_door"" == 0) and (this animationPhase ""Open_latch"" == 1)";
 			statement="PVDZE_handleSafeGear = [player,this,4];publicVariableServer ""PVDZE_handleSafeGear"";this animate [""Open_latch"", 0]";
 		};
 		class Unlock_Door : Open_Door

--- a/SQF/dayz_code/Configs/CfgVehicles/DZE/Doors.hpp
+++ b/SQF/dayz_code/Configs/CfgVehicles/DZE/Doors.hpp
@@ -360,7 +360,7 @@ class Land_DZE_WoodDoorLocked: Land_DZE_WoodDoorLocked_Base {
 			displayName=$STR_EPOCH_DOORS_LOCK;
 			//condition="(this animationPhase ""Open_door"" == 0) and (this animationPhase ""Open_hinge"" == 1)";
 			condition="(!keypadCancel and DZE_Lock_Door == (this getvariable['CharacterID','0'])) and (this animationPhase ""Open_door"" == 0) and (this animationPhase ""Open_hinge"" == 1)";
-			statement="PVDZE_handleSafeGear = [player,this,4,DZE_Lock_Door];publicVariableServer ""PVDZE_handleSafeGear"";this animate [""Open_latch"", 0]";
+			statement="PVDZE_handleSafeGear = [player,this,4,DZE_Lock_Door];publicVariableServer ""PVDZE_handleSafeGear"";this animate [""Open_hinge"", 0]";
 		};
 		class Unlock_Door : Open_Door
 		{
@@ -460,7 +460,7 @@ class Land_DZE_LargeWoodDoorLocked: Land_DZE_WoodDoorLocked_Base {
 			displayName=$STR_EPOCH_DOORS_LOCK;
 			//condition="(this animationPhase ""Open_door"" == 0) and (this animationPhase ""Open_hinge"" == 1)";
 			condition="(!keypadCancel and DZE_Lock_Door == (this getvariable['CharacterID','0'])) and (this animationPhase ""Open_door"" == 0) and (this animationPhase ""Open_hinge"" == 1)";
-			statement="PVDZE_handleSafeGear = [player,this,4,DZE_Lock_Door];publicVariableServer ""PVDZE_handleSafeGear"";this animate [""Open_latch"", 0]";
+			statement="PVDZE_handleSafeGear = [player,this,4,DZE_Lock_Door];publicVariableServer ""PVDZE_handleSafeGear"";this animate [""Open_hinge"", 0]";
 		};
 		class Unlock_Door : Open_Door
 		{
@@ -560,7 +560,7 @@ class Land_DZE_GarageWoodDoorLocked: Land_DZE_WoodDoorLocked_Base {
 			displayName=$STR_EPOCH_DOORS_LOCK;
 			//condition="(this animationPhase ""Open_door"" == 0) and (this animationPhase ""Open_hinge"" == 1)";
 			condition="(!keypadCancel and DZE_Lock_Door == (this getvariable['CharacterID','0'])) and (this animationPhase ""Open_door"" == 0) and (this animationPhase ""Open_hinge"" == 1)";
-			statement="PVDZE_handleSafeGear = [player,this,4,DZE_Lock_Door];publicVariableServer ""PVDZE_handleSafeGear"";this animate [""Open_latch"", 0]";
+			statement="PVDZE_handleSafeGear = [player,this,4,DZE_Lock_Door];publicVariableServer ""PVDZE_handleSafeGear"";this animate [""Open_hinge"", 0]";
 		};
 		class Unlock_Door : Open_Door
 		{

--- a/SQF/dayz_code/actions/AdvancedTrading/functions/z_at_logTrade.sqf
+++ b/SQF/dayz_code/actions/AdvancedTrading/functions/z_at_logTrade.sqf
@@ -1,38 +1,29 @@
 private ["_Z_logTrade","_classNames","_className","_amounts","_amount","_prices","_price","_quantity","_queueAmounts","_queueNames","_queuePrices","_index","_buyOrSell"];
 
 _Z_logTrade = {
-	private ["_buyOrSell","_className","_container","_currency","_price","_quantity","_tCost"];
+	private ["_buyOrSell","_className","_container","_price","_quantity"];
 
 	_className = _this select 0;
 	_quantity = _this select 1;
 	_buyOrSell = _this select 2;
 	_price = _this select 3;
 	_container = switch (Z_SellingFrom) do {
-	case 0 : {localize "STR_EPOCH_TRADE_BACKPACK"};
-	case 1 : {localize "STR_EPOCH_TRADE_VEHICLE"};
-	case 2 : {localize "STR_UI_GEAR"};
+		case 0 : {localize "STR_EPOCH_TRADE_BACKPACK"};
+		case 1 : {localize "STR_EPOCH_TRADE_VEHICLE"};
+		case 2 : {localize "STR_UI_GEAR"};
 	};
-	_tCost = [_price,true] call Z_calcCurrency;
-	_currency = if (Z_SingleCurrency) then {CurrencyName} else {""};
+	_price = if (Z_singleCurrency) then {format ["%1 %2",[_price] call BIS_fnc_numberText,CurrencyName]} else {[_price,true] call Z_calcCurrency;};
 
 	// Log to client RPT
-	if (Z_SingleCurrency) then {
-		if (_buyOrSell == "buy") then {
-			diag_log format["%5: Purchased %4x %1 into %7 at %2 for %3 %6",_className,inTraderCity,_price,_quantity,localize "STR_EPOCH_PLAYER_289",_currency,_container];
-		} else {
-			diag_log format["%5: Sold %4x %1 from %7 at %2 for %3 %6",_className,inTraderCity,_price,_quantity,localize "STR_EPOCH_PLAYER_289",_currency,_container];
-		};
+	if (_buyOrSell == "buy") then {
+		diag_log format["%1: Purchased %2x %3 into %4 at %5 for %6",localize "STR_EPOCH_PLAYER_289",_quantity,_className,_container,inTraderCity,_price];
 	} else {
-		if (_buyOrSell == "buy") then {
-			diag_log format["%5: Purchased %4x %1 into %7 at %2 for %3",_className,inTraderCity,_tCost,_quantity,localize "STR_EPOCH_PLAYER_289",_currency,_container];
-		} else {
-			diag_log format["%5: Sold %4x %1 from %7 at %2 for %3",_className,inTraderCity,_tCost,_quantity,localize "STR_EPOCH_PLAYER_289",_currency,_container];
-		};
-	};	
-
+		diag_log format["%1: Sold %2x %3 from %4 at %5 for %6",localize "STR_EPOCH_PLAYER_289",_quantity,_className,_container,inTraderCity,_price];
+	};
+	
 	// Log to server RPT
 	if (DZE_serverLogTrades) then {
-		PVDZE_obj_Trade = [player,0,if (_buyOrSell == "buy") then {0} else {1},_className,inTraderCity,_currency,if (Z_singleCurrency) then {_price} else {_tCost},_quantity,_container,false];
+		PVDZE_obj_Trade = [player,0,if (_buyOrSell == "buy") then {0} else {1},_className,inTraderCity,false,_price,_quantity,_container,false];
 		publicVariableServer "PVDZE_obj_Trade";
 	};
 };

--- a/SQF/dayz_code/actions/AdvancedTrading/functions/z_at_logTrade.sqf
+++ b/SQF/dayz_code/actions/AdvancedTrading/functions/z_at_logTrade.sqf
@@ -12,7 +12,7 @@ _Z_logTrade = {
 		case 1 : {localize "STR_EPOCH_TRADE_VEHICLE"};
 		case 2 : {localize "STR_UI_GEAR"};
 	};
-	_price = if (Z_singleCurrency) then {format ["%1 %2",[_price] call BIS_fnc_numberText,CurrencyName]} else {[_price,true] call Z_calcCurrency;};
+	_price = if (Z_singleCurrency) then {format ["%1 %2",[_price] call BIS_fnc_numberText,CurrencyName]} else {[_price,true] call Z_calcCurrency};
 
 	// Log to client RPT
 	if (_buyOrSell == "buy") then {

--- a/SQF/dayz_code/compile/player_unlockDoor.sqf
+++ b/SQF/dayz_code/compile/player_unlockDoor.sqf
@@ -60,7 +60,13 @@ if (!isNull dayz_selectedDoor) then {
 			};
 			dayz_UnlockTime = 5;
 			dayz_lastCodeFail = 0;
+			
+			PVDZE_handleSafeGear = [player,_obj,5,if (_doorMethod == "EYE") then {"EYESCAN"} else {DZE_Lock_Door}];
+			publicVariableServer "PVDZE_handleSafeGear";
 		} else {
+			PVDZE_handleSafeGear = [player,_obj,6,if (_doorMethod == "EYE") then {"EYESCAN"} else {DZE_Lock_Door}];
+			publicVariableServer "PVDZE_handleSafeGear";
+			
 			["Working",0,[100,15,10,0]] call dayz_NutritionSystem;
 			DZE_Lock_Door = "";
 			[player,"combo_locked",0,false] call dayz_zombieSpeak;

--- a/SQF/dayz_code/compile/player_unlockVault.sqf
+++ b/SQF/dayz_code/compile/player_unlockVault.sqf
@@ -77,6 +77,9 @@ if (_ComboMatch || (_ownerID == dayz_playerUID)) then {
 		format[localize "str_player_beinglooted",_text] call dayz_rollingMessages;
 	};
 } else {
+	PVDZE_handleSafeGear = [player,_obj,3,dayz_combination];
+	publicVariableServer "PVDZE_handleSafeGear";
+	
 	["Working",0,[100,15,10,0]] call dayz_NutritionSystem;
 	player playActionNow "Medic";
 	uiSleep 1;

--- a/SQF/dayz_server/compile/server_handleSafeGear.sqf
+++ b/SQF/dayz_server/compile/server_handleSafeGear.sqf
@@ -3,7 +3,7 @@ private ["_backpacks","_charID","_clientID","_dir","_holder","_lockCode","_lockC
 _player = _this select 0;
 _obj = _this select 1;
 _status = _this select 2;
-_suppliedCode = if (count _this > 3) then {_this select 3} else {0};
+if (count _this > 3) then {_suppliedCode = _this select 3;};
 _name = if (alive _player) then {name _player} else {"Dead Player"};
 
 _type = typeOf _obj;
@@ -33,7 +33,7 @@ _statusText = switch (_status) do {
 };
 
 if (isNull _obj) exitWith {
-	diag_log format["ERROR: server_handleSafeGear called with Null safe object by %1(%2). %3 attempt failed.",_name,_playerUID,_statusText];
+	diag_log format["ERROR: server_handleSafeGear called with Null object by %1 (%2). %3 attempt failed.",_name,_playerUID,_statusText];
 	if (_status < 3) then {
 		dze_waiting = "fail";
 		_clientID publicVariableClient "dze_waiting";

--- a/SQF/dayz_server/compile/server_handleSafeGear.sqf
+++ b/SQF/dayz_server/compile/server_handleSafeGear.sqf
@@ -14,7 +14,7 @@ _charID = _obj getVariable ["CharacterID","0"];
 _objectID = _obj getVariable ["ObjectID","0"];
 _objectUID = _obj getVariable ["ObjectUID","0"];
 _ownerID = _obj getVariable ["ownerPUID","0"];
-_lockCode = "0";
+_lockCode = _charID;
 
 // Player may have disconnected or died before message send. Attempt lock/unlock/pack/save procedure anyway
 if (isNull _player) then {diag_log "ERROR: server_handleSafeGear called with Null player object";};
@@ -132,7 +132,6 @@ if (_status < 4) then {
 	_type = switch _type do {
 		case "VaultStorage";
 		case "VaultStorageLocked": {
-			_lockCode = _charID;
 			"Safe"
 		};
 		case "LockboxStorage";
@@ -144,9 +143,7 @@ if (_status < 4) then {
 	};
 };
 
-_lockCode = if (_type in DZE_DoorsLocked) then {_charID} else {_lockCode};
-
-if (_status == 3 || {_status == 6}) then {
+if (_statusText == "FAILED unlocking") then {
 	_message = format["%1 (%2) %3 %4 with code: %5 (actual: %8) @%6 %7",_name,_playerUID,_statusText,_type,_suppliedCode,mapGridPosition _pos,_pos,_lockCode];
 } else {
 	_message = format["%1 (%2) %3 %4 with code: %5 @%6 %7",_name,_playerUID,_statusText,_type,_lockCode,mapGridPosition _pos,_pos];

--- a/SQF/dayz_server/compile/server_handleSafeGear.sqf
+++ b/SQF/dayz_server/compile/server_handleSafeGear.sqf
@@ -1,8 +1,9 @@
-private ["_backpacks","_charID","_clientID","_dir","_holder","_lockCode","_lockColor","_lockedClass","_magazines","_name","_obj","_objectID","_objectUID","_ownerID","_packedClass","_player","_playerUID","_pos","_status","_statusText","_type","_unlockedClass","_vector","_weapons"];
+private ["_backpacks","_charID","_clientID","_dir","_holder","_lockCode","_lockColor","_lockedClass","_magazines","_name","_obj","_objectID","_objectUID","_ownerID","_packedClass","_player","_playerUID","_pos","_status","_statusText","_type","_unlockedClass","_vector","_weapons","_message","_suppliedCode","_fnc_lockCode"];
 
 _player = _this select 0;
 _obj = _this select 1;
 _status = _this select 2;
+_suppliedCode = if (count _this > 3) then {_this select 3} else {0};
 _name = if (alive _player) then {name _player} else {"Dead Player"};
 
 _type = typeOf _obj;
@@ -22,15 +23,21 @@ _clientID = owner _player;
 _playerUID = getPlayerUID _player;
 
 _statusText = switch (_status) do {
-	case 0: {"UNLOCKED"};
-	case 1: {"LOCKED"};
-	case 2: {"PACKED"};
+	case 0: {"UNLOCKED"}; // unlock safe/lockbox
+	case 1: {"LOCKED"}; // lock safe/lockbox
+	case 2: {"PACKED"}; // pack safe/lockbox
+	case 3: {"FAILED unlocking"}; // failed unlock safe/lockbox
+	case 4: {"LOCKED"}; // lock door
+	case 5: {"UNLOCKED"}; // unlock door
+	case 6: {"FAILED unlocking"}; // failed unlocking door
 };
 
 if (isNull _obj) exitWith {
 	diag_log format["ERROR: server_handleSafeGear called with Null safe object by %1(%2). %3 attempt failed.",_name,_playerUID,_statusText];
-	dze_waiting = "fail";
-	_clientID publicVariableClient "dze_waiting";
+	if (_status < 3) then {
+		dze_waiting = "fail";
+		_clientID publicVariableClient "dze_waiting";
+	};
 };
 
 switch (_status) do {
@@ -104,27 +111,49 @@ switch (_status) do {
 	};
 };
 
-_type = switch _type do {
-    case "VaultStorage";
-    case "VaultStorageLocked": {
-		_lockCode = _charID;
-		"Safe"
-	};
-    case "LockboxStorage";
-    case "LockboxStorageLocked": {
-		_lockColor = "";
-		_lockCode =  parseNumber _charID;
-		_lockCode = _lockCode - 10000;
-		if (_lockCode <= 99) then { _lockColor = "Red"; };
-		if (_lockCode >= 100 && _lockCode <= 199) then { _lockColor = "Green"; _lockCode = _lockCode - 100; };
-		if (_lockCode >= 200) then { _lockColor = "Blue"; _lockCode = _lockCode - 200; };
-		if (_lockCode <= 9) then { _lockCode = format["0%1", _lockCode]; };
-		_lockCode = format ["%1%2",_lockColor,_lockCode];
-		"LockBox"
+_fnc_lockCode = {
+	private ["_color","_code"];
+
+	if (_this == "") exitWith {0};
+	_color = "";
+	_code = if (typeName _this == "STRING") then {parseNumber _this} else {_this};
+	_code = _code - 10000;
+	
+	if (_code <= 99) then {_color = localize "STR_TEAM_RED";};
+	if (_code >= 100 && _code <= 199) then {_color = localize "STR_TEAM_GREEN"; _code = _code - 100;};
+	if (_code >= 200) then {_color = localize "STR_TEAM_BLUE"; _code = _code - 200;};
+	if (_code <= 9) then {_code = format["0%1", _code];};
+	_code = format ["%1%2",_color,_code];
+	
+	_code
+};
+
+if (_status < 4) then {
+	_type = switch _type do {
+		case "VaultStorage";
+		case "VaultStorageLocked": {
+			_lockCode = _charID;
+			"Safe"
+		};
+		case "LockboxStorage";
+		case "LockboxStorageLocked": {
+			_lockCode = _charID call _fnc_lockCode;
+			if (_status == 3) then {_suppliedCode = _suppliedCode call _fnc_lockCode;};
+			"LockBox"
+		};
 	};
 };
 
-diag_log format["%1 (%2) %3 %4 with code: %5 @%6 (%7)",_name,_playerUID,_statusText,_type,_lockCode,mapGridPosition _pos,_pos];
+_lockCode = if (_type in DZE_DoorsLocked) then {_charID} else {_lockCode};
 
-dze_waiting = "success";
-_clientID publicVariableClient "dze_waiting";
+if (_status == 3 || {_status == 6}) then {
+	_message = format["%1 (%2) %3 %4 with code: %5 (actual: %8) @%6 %7",_name,_playerUID,_statusText,_type,_suppliedCode,mapGridPosition _pos,_pos,_lockCode];
+} else {
+	_message = format["%1 (%2) %3 %4 with code: %5 @%6 %7",_name,_playerUID,_statusText,_type,_lockCode,mapGridPosition _pos,_pos];
+};
+
+diag_log _message;
+if (_status < 3) then {
+	dze_waiting = "success";
+	_clientID publicVariableClient "dze_waiting";
+};

--- a/SQF/dayz_server/compile/server_tradeObject.sqf
+++ b/SQF/dayz_server/compile/server_tradeObject.sqf
@@ -1,4 +1,4 @@
-private ["_player","_playerUID","_name","_traderid","_buyorsell","_data","_result","_key","_outcome","_clientID","_price","_quantity","_container","_return"];
+private ["_player","_playerUID","_name","_traderid","_buyorsell","_data","_result","_key","_outcome","_clientID","_price","_quantity","_container","_return","_classname","_traderCity","_currency","_message"];
 
 _player =		_this select 0;
 _traderID = 	_this select 1;
@@ -10,7 +10,7 @@ _price =		_this select 6;
 
 _clientID = 	owner _player;
 _playerUID = 	getPlayerUID _player;
-_name = 		if (alive _player) then { name _player; } else { "Dead Player"; };
+_name = 		if (alive _player) then {name _player} else {"Dead Player"};
 
 if (count _this > 7) then {
 	_quantity = _this select 7;
@@ -22,14 +22,15 @@ if (count _this > 7) then {
 	_return = true;
 };
 
-if (typeName _price  == "SCALAR") then { _price = format ["%1 %2",_price,_currency]; } else { _price = format ["%1",_price]; };
+if (typeName _currency  == "STRING") then {_price = format ["%1 %2",_price,_currency];};
 
-if (_buyorsell == 0) then { //Buy
-	diag_log format["%8: %1 (%2) purchased %6x %3 into %7 at %4 for %5", _name, _playerUID, _classname, _traderCity, _price, _quantity,_container,localize "STR_EPOCH_PLAYER_289"];
-} else { //SELL
-	diag_log format["%8: %1 (%2) sold %6x %3 from %7 at %4 for %5",_name, _playerUID, _classname, _traderCity, _price, _quantity,_container,localize "STR_EPOCH_PLAYER_289"];
+if (_buyorsell == 0) then { // Buy
+	_message = format["%1: %2 (%3) purchased %4x %5 into %6 at %7 for %8",localize "STR_EPOCH_PLAYER_289",_name,_playerUID,_quantity,_classname,_container,_traderCity,_price];
+} else { // Sell
+	_message = format["%1: %2 (%3) sold %4x %5 from %6 at %7 for %8",localize "STR_EPOCH_PLAYER_289",_name,_playerUID,_quantity,_classname,_container,_traderCity,_price];
 };
 
+diag_log _message;
 if (DZE_ConfigTrader) then {
 	_outcome = "PASS";
 } else {
@@ -44,7 +45,7 @@ if (DZE_ConfigTrader) then {
 
 if (_return) then {
 	dayzTradeResult = _outcome;
-	if(!isNull _player) then {
+	if (!isNull _player) then {
 		_clientID publicVariableClient "dayzTradeResult";
 	};
 };


### PR DESCRIPTION
This adds logging for both safes and lockboxes for failed code attempts.

Also adds logging for locking, unlocking and failed code attempts for doors.

```"salival (playerUID) FAILED unlocking LockBox with code: Red11 (actual: Red57) @110069 [11044.4,8438.32,0.652]"
"salival (playerUID) UNLOCKED LockBox with code: Green22 @110069 [11040.6,8438.91,0.834]"
"salival (playerUID) PACKED LockBox with code: Green22 @110069 [11040.6,8438.91,0.834]"
"salival (playerUID) UNLOCKED CinderWallDoorSmallLocked_DZ with code: 559 @110069 [11015.4,8458.74,5.272]"
"salival (playerUID) LOCKED CinderWallDoorSmallLocked_DZ with code: 559 @110069 [11015.4,8458.74,5.272]"
"salival (playerUID) FAILED unlocking CinderWallDoorSmallLocked_DZ with code: EYESCAN (actual: 559) @110069 [11015.4,8458.74,5.272]"
"salival (playerUID) FAILED unlocking CinderWallDoorSmallLocked_DZ with code: 100 (actual: 559) @110069 [11015.4,8458.74,5.272]"
"salival (playerUID) UNLOCKED CinderWallDoorSmallLocked_DZ with code: 559 @110069 [11015.4,8458.74,5.272]"
"salival (playerUID) LOCKED CinderWallDoorSmallLocked_DZ with code: 559 @110069 [11015.4,8458.74,5.272]"
```