### PR TITLE
Allow merlin_hc3 to be repaired properly

### DIFF
--- a/CHANGE LOG 1.0.6.1.txt
+++ b/CHANGE LOG 1.0.6.1.txt
@@ -50,6 +50,7 @@
 [FIXED] RU crates having zero cargo capacity and wrong classname DZ_ExplosivesBoxRU in loot table. #1852 @oiad
 [FIXED] Combining M24 or 2Rnd shotgun ammo can no longer be abused to dupe mags via the method described in #1848. @DeVloek
 [FIXED] Rapid starvation or dehydration when using chainsaw, chopping wood or pushing plane.
+[FIXED] Both Merlin_HC3's can now be repaired properly by manually fixing the glass. #1856 @schwanzkopfhegel @oiad
 
 [NOTE] The fixes below are included in the 1.0.6 Build C server package released December 29th, 2016 (http://dayzepoch.com/a2dayzepoch.php)
 [FIXED] Hive child 309 errors that resulted in broken saving of newly built storage object inventory. @icomrade

--- a/SQF/dayz_code/Configs/CfgVehicles/RepairParts.hpp
+++ b/SQF/dayz_code/Configs/CfgVehicles/RepairParts.hpp
@@ -69,6 +69,48 @@ class RepairParts : AllVehicles
 	class HitGlass6 {
 		part = "PartGlass";
 	};
+	class HitGlass7 {
+		part = "PartGlass";
+	};
+	class HitGlass8 {
+		part = "PartGlass";
+	};
+	class HitGlass9 {
+		part = "PartGlass";
+	};
+	class HitGlass10 {
+		part = "PartGlass";
+	};
+	class HitGlass11 {
+		part = "PartGlass";
+	};
+	class HitGlass12 {
+		part = "PartGlass";
+	};
+	class HitGlass13 {
+		part = "PartGlass";
+	};
+	class HitGlass14 {
+		part = "PartGlass";
+	};
+	class HitGlass15 {
+		part = "PartGlass";
+	};
+	class HitGlass16 {
+		part = "PartGlass";
+	};
+	class HitGlass17 {
+		part = "PartGlass";
+	};
+	class HitGlass18 {
+		part = "PartGlass";
+	};
+	class HitGlass19 {
+		part = "PartGlass";
+	};
+	class HitGlass20 {
+		part = "PartGlass";
+	};
 	class HitVRotor {
 		part = "PartGeneric";
 	};


### PR DESCRIPTION
The merlin has 20 windows + 2 side windows, glass 7 - 20 were showing up
as PartGeneric and breaking the repair script for some reason.

https://github.com/EpochModTeam/DayZ-Epoch/issues/1856#issue-199105821