### PR TITLE
Fix handleSafeGear not showing the failed code correctly

### DIFF
--- a/SQF/dayz_server/compile/server_handleSafeGear.sqf
+++ b/SQF/dayz_server/compile/server_handleSafeGear.sqf
@@ -18,7 +18,7 @@ _lockCode = _charID;
 
 if (count _this > 3) then {
 	_suppliedCode = _this select 3;
-	_lockCode = _suppliedCode;
+	if (_status != 3 && {_status != 6}) then {_lockCode = _suppliedCode;};
 };
 
 // Player may have disconnected or died before message send. Attempt lock/unlock/pack/save procedure anyway


### PR DESCRIPTION
Was displaying failed code as the actual code (obviously wrong)