### PR TITLE
fix epoch_tempKeys.sqf making massive arrays.

### DIFF
--- a/SQF/dayz_code/compile/epoch_tempKeys.sqf
+++ b/SQF/dayz_code/compile/epoch_tempKeys.sqf
@@ -1,14 +1,16 @@
 private ["_temp_keys","_temp_keys_names","_key_colors","_ownerKeyId","_ownerKeyName"];
 _temp_keys = [];
 _temp_keys_names = [];
-// find available keys
+
 _key_colors = ["ItemKeyYellow","ItemKeyBlue","ItemKeyRed","ItemKeyGreen","ItemKeyBlack"];
+
 {
 	if (configName(inheritsFrom(configFile >> "CfgWeapons" >> _x)) in _key_colors) then {
 		_ownerKeyId = getNumber(configFile >> "CfgWeapons" >> _x >> "keyid");
 		_ownerKeyName = getText(configFile >> "CfgWeapons" >> _x >> "displayName");
-		_temp_keys_names set [_ownerKeyId,_ownerKeyName];
+		_temp_keys_names set [count _temp_keys_names,_ownerKeyName];
 		_temp_keys set [count _temp_keys,str(_ownerKeyId)];
 	};
 } count (items player);
+
 [_temp_keys,_temp_keys_names]

--- a/SQF/dayz_code/compile/fn_selfActions.sqf
+++ b/SQF/dayz_code/compile/fn_selfActions.sqf
@@ -5,7 +5,7 @@ scriptName "Functions\misc\fn_selfActions.sqf";
 	- [] call fnc_usec_selfActions;
 ************************************************************/
 if (dayz_actionInProgress) exitWith {};
-private ["_canPickLight","_text","_unlock","_lock","_totalKeys","_temp_keys","_temp_key_name","_temp_keys_names",
+private ["_canPickLight","_text","_unlock","_lock","_totalKeys","_temp_keys","_temp_keys_names",
 "_hasKey","_oldOwner","_hasAttached","_isZombie","_isHarvested","_isMan","_isFuel","_hasRawMeat","_hastinitem","_player_deleteBuild",
 "_player_lockUnlock_crtl","_displayName","_hasIgnitors","_menu","_menu1","_allowTow","_liftHeli","_found","_posL","_posC","_height","_attached",
 "_combi","_findNearestGen","_humanity_logic","_low_high","_cancel","_buy","_buyV","_humanity","_traderMenu","_warn","_typeOfCursorTarget",
@@ -120,15 +120,11 @@ if (_inVehicle) then {
 			_temp_keys_names = _totalKeys select 1;	
 			_hasKey = _vehicleOwnerID in _temp_keys;
 			_oldOwner = (_vehicleOwnerID == _uid);
-			
-			{
-				if (_vehicleOwnerID == _x) exitWith {_temp_key_name = _temp_keys_names select _forEachIndex};
-			} forEach _temp_keys;
 		
 			_text = getText (configFile >> "CfgVehicles" >> (typeOf DZE_myVehicle) >> "displayName");
 			if (locked DZE_myVehicle) then {
 				if (_hasKey || _oldOwner) then {
-					_unlock = DZE_myVehicle addAction [format[localize "STR_EPOCH_ACTIONS_UNLOCK",_text], "\z\addons\dayz_code\actions\unlock_veh.sqf",[DZE_myVehicle,_temp_key_name], 2, false, true];
+					_unlock = DZE_myVehicle addAction [format[localize "STR_EPOCH_ACTIONS_UNLOCK",_text], "\z\addons\dayz_code\actions\unlock_veh.sqf",[DZE_myVehicle,(_temp_keys_names select (_temp_keys find _vehicleOwnerID))], 2, false, true];
 					s_player_lockUnlockInside set [count s_player_lockUnlockInside,_unlock];
 					s_player_lockUnlockInside_ctrl = 1;
 				} else {
@@ -694,15 +690,10 @@ if (!isNull _cursorTarget && !_inVehicle && !_isPZombie && (player distance _cur
 			_temp_keys = _totalKeys select 0;
 			_temp_keys_names = _totalKeys select 1;
 			_hasKey = _characterID in _temp_keys;
-
-			{
-				if (_characterID == _x) exitWith {_temp_key_name = _temp_keys_names select _forEachIndex};
-			} forEach _temp_keys;
-
 			_oldOwner = (_characterID == _uid);
 			if (locked _cursorTarget) then {
 				if (_hasKey || _oldOwner) then {
-					_unlock = player addAction [format[localize "STR_EPOCH_ACTIONS_UNLOCK",_text], "\z\addons\dayz_code\actions\unlock_veh.sqf",[_cursorTarget,_temp_key_name], 2, true, true];
+					_unlock = player addAction [format[localize "STR_EPOCH_ACTIONS_UNLOCK",_text], "\z\addons\dayz_code\actions\unlock_veh.sqf",[_cursorTarget,(_temp_keys_names select (_temp_keys find _characterID))], 2, true, true];
 					s_player_lockunlock set [count s_player_lockunlock,_unlock];
 					s_player_lockUnlock_crtl = 1;
 				} else {

--- a/SQF/dayz_code/compile/fn_selfActions.sqf
+++ b/SQF/dayz_code/compile/fn_selfActions.sqf
@@ -5,7 +5,7 @@ scriptName "Functions\misc\fn_selfActions.sqf";
 	- [] call fnc_usec_selfActions;
 ************************************************************/
 if (dayz_actionInProgress) exitWith {};
-private ["_canPickLight","_text","_unlock","_lock","_totalKeys","_temp_keys","_temp_keys_names",
+private ["_canPickLight","_text","_unlock","_lock","_totalKeys","_temp_keys","_temp_key_name","_temp_keys_names",
 "_hasKey","_oldOwner","_hasAttached","_isZombie","_isHarvested","_isMan","_isFuel","_hasRawMeat","_hastinitem","_player_deleteBuild",
 "_player_lockUnlock_crtl","_displayName","_hasIgnitors","_menu","_menu1","_allowTow","_liftHeli","_found","_posL","_posC","_height","_attached",
 "_combi","_findNearestGen","_humanity_logic","_low_high","_cancel","_buy","_buyV","_humanity","_traderMenu","_warn","_typeOfCursorTarget",
@@ -120,10 +120,15 @@ if (_inVehicle) then {
 			_temp_keys_names = _totalKeys select 1;	
 			_hasKey = _vehicleOwnerID in _temp_keys;
 			_oldOwner = (_vehicleOwnerID == _uid);
+			
+			{
+				if (_vehicleOwnerID == _x) exitWith {_temp_key_name = _temp_keys_names select _forEachIndex};
+			} forEach _temp_keys;
+		
 			_text = getText (configFile >> "CfgVehicles" >> (typeOf DZE_myVehicle) >> "displayName");
 			if (locked DZE_myVehicle) then {
 				if (_hasKey || _oldOwner) then {
-					_unlock = DZE_myVehicle addAction [format[localize "STR_EPOCH_ACTIONS_UNLOCK",_text], "\z\addons\dayz_code\actions\unlock_veh.sqf",[DZE_myVehicle,(_temp_keys_names select (parseNumber _vehicleOwnerID))], 2, false, true];
+					_unlock = DZE_myVehicle addAction [format[localize "STR_EPOCH_ACTIONS_UNLOCK",_text], "\z\addons\dayz_code\actions\unlock_veh.sqf",[DZE_myVehicle,_temp_key_name], 2, false, true];
 					s_player_lockUnlockInside set [count s_player_lockUnlockInside,_unlock];
 					s_player_lockUnlockInside_ctrl = 1;
 				} else {
@@ -689,10 +694,15 @@ if (!isNull _cursorTarget && !_inVehicle && !_isPZombie && (player distance _cur
 			_temp_keys = _totalKeys select 0;
 			_temp_keys_names = _totalKeys select 1;
 			_hasKey = _characterID in _temp_keys;
+
+			{
+				if (_characterID == _x) exitWith {_temp_key_name = _temp_keys_names select _forEachIndex};
+			} forEach _temp_keys;
+
 			_oldOwner = (_characterID == _uid);
 			if (locked _cursorTarget) then {
 				if (_hasKey || _oldOwner) then {
-					_unlock = player addAction [format[localize "STR_EPOCH_ACTIONS_UNLOCK",_text], "\z\addons\dayz_code\actions\unlock_veh.sqf",[_cursorTarget,(_temp_keys_names select (parseNumber _characterID))], 2, true, true];
+					_unlock = player addAction [format[localize "STR_EPOCH_ACTIONS_UNLOCK",_text], "\z\addons\dayz_code\actions\unlock_veh.sqf",[_cursorTarget,_temp_key_name], 2, true, true];
 					s_player_lockunlock set [count s_player_lockunlock,_unlock];
 					s_player_lockUnlock_crtl = 1;
 				} else {


### PR DESCRIPTION
epoch_tempKeys was making a massive array every time it was called due
to them setting the array size to the _ownerKeyId instead of count
_temp_keys_names.

For example: Call this function 10k times in testkit and see it lag the
client due to making a massive array over and over again.

```
"[[["9379"],[<null>,<null>,<null>,<null>,<null>,<null>,<null>,<null>,<null>,<null>,<null>,<null>,<null>,<null>,<null>,<null>,<null>,<null>,<null>,<null>,<null>,<null>,<null>,<null>,<null>,<null>,<null>,<null>,<null>,<null>,<null>,<null>,<null>,<null>,<null>,<null>,<null>,<null>,<null>,<null>,<null>,<null>,<null>,<null>,<null>,<null>,<null>,<null>,<null>,<null>,<null>,<null>,<null>,<null>,<null>,<null>,<null>,<null>,<null>,<null>,<null>,<null>,<null>,<null>,<null>,<null>,<null>,<null>,<null>,<null>,<null>,<null>,<null>,<null>,<null>,<null>,<null>,<null>,<null>,<null>,<null>,<null>,<null>,<null>,<null>,<null>,<null>,<null>,<null>,<null>,<null>,<null>,<null>,<null>,<null>,<null>,<null>,<null>,<null>,<null>,<null>,<null>,<null>,<null>,<null>,<null>,<null>,<null>,<null>,<null>,<null>,<null>,<null>,<null>,<null>,<null>,<null>,<null>,<null>,<null>,<null>,<null>,<null>,<null>,<null>,<null>,<null>,<null>,<null>,<null>,<null>,<null>,<null>,<null>,<null>,<null>,<null>,<null>,<null>,<null>,<null>,<null>,<null>,<null>,<n
"Test script finished. Code took 0.440002 seconds to run"
```

With fixed code:
```
"[[["9379"],["Yellow Key (65d0)"]],false]"
"Test script finished. Code took 0.000991821 seconds to run"
```