### PR TITLE
Stop server_publishVehicle3 duping a vehicle if hive fails to update

### DIFF
--- a/CHANGE LOG 1.0.6.1.txt
+++ b/CHANGE LOG 1.0.6.1.txt
@@ -83,6 +83,7 @@
 [FIXED] Error handling upgraded 1051 databases that resulted in a <null> value for "rh_factor" and array for "bloodtype" in character_data medical field. @ebayShopper
 [FIXED] Error in server_playerSetup that resulted in a <null> value for dayz_onBack in character_data inventory if player had no weapon on back. @ebayShopper 
 [FIXED] Doors and plots not getting cleaned up properly. See new MaintenanceObjects variable and explanation in HiveExt.ini. @icomrade
+[FIXED] server_PublishVehicle3 will no longer dupe a vehicle if it fails to read the vehicle back from the database. @oiad
 
 [REMOVED] Antiwall glitch blocks for vanilla hospitals since Epoch uses DayZero hospitals. @jOoPs
 [REMOVED] "Take ownership" on plot pole due to it being unnecessary and causing base objects to duplicate. #1811 @BNG-Lance @Clanwarfare

--- a/SQF/dayz_code/compile/player_upgradeVehicle.sqf
+++ b/SQF/dayz_code/compile/player_upgradeVehicle.sqf
@@ -130,10 +130,16 @@ if (_IsNearVehicle >= 1) then {
 						PVDZE_veh_Upgrade = [_vehicle,[_dir,_location],_newclassname,true,_objectCharacterID,player];
 						publicVariableServer "PVDZE_veh_Upgrade";
 
-						localize "STR_EPOCH_VEHUP_SUCCESS" call dayz_rollingMessages;
-						
 						//Wait for hive to finish spawning vehicle. Prevents dupe via player queuing multiple upgrades.
 						waitUntil {!isNil "dze_waiting"};
+
+						if (dze_waiting == "fail") then {
+						    {player addMagazine _x;} count _temp_removed_array_mag;
+    						{player addWeapon _x;} count _temp_removed_array_wep;
+    						format[localize "str_crafting_failed",_newclassname] call dayz_rollingMessages;
+						} else {
+    						localize "STR_EPOCH_VEHUP_SUCCESS" call dayz_rollingMessages;
+						};
 					};
 				}
 				else {

--- a/SQF/dayz_server/compile/server_deleteObj.sqf
+++ b/SQF/dayz_server/compile/server_deleteObj.sqf
@@ -1,5 +1,5 @@
 /*
-[_objectID,_objectUID] call server_deleteObj;
+[_objectID,_objectUID,_activatingPlayer] call server_deleteObj;
 */
 private["_id","_uid","_key","_activatingPlayer"];
 _id 	= _this select 0;

--- a/SQF/dayz_server/compile/server_publishVehicle3.sqf
+++ b/SQF/dayz_server/compile/server_publishVehicle3.sqf
@@ -80,7 +80,10 @@ _key call server_hiveWrite;
 	};
 
 	if (!_done) exitWith {
-		diag_log("CUSTOM: failed to get id for : " + str(_uid));
+		diag_log("HIVE-pv3: failed to get id for : " + str(_uid));
+		_key = format["CHILD:310:%1:",_uid];
+		_key call server_hiveWrite;
+		
 		dze_waiting = "fail";
 		(owner _activatingPlayer) publicVariableClient "dze_waiting";
 	};
@@ -102,6 +105,7 @@ _key call server_hiveWrite;
 
 	// remove old vehicle from DB
 	[_objectID,_objectUID,_activatingPlayer] call server_deleteObj;
+	uiSleep 1;
 
 	// switch var to new vehicle at this point.
 	_object = _newobject;
@@ -137,9 +141,7 @@ _key call server_hiveWrite;
 	} count _objWpnTypes;
 
 	_object setVariable ["ObjectID", _oid, true];
-	
 	_object setVariable ["lastUpdate",time];
-	
 	_object setVariable ["CharacterID", _characterID, true];
 
 	dayz_serverObjectMonitor set [count dayz_serverObjectMonitor,_object];

--- a/SQF/dayz_server/compile/server_publishVehicle3.sqf
+++ b/SQF/dayz_server/compile/server_publishVehicle3.sqf
@@ -105,7 +105,6 @@ _key call server_hiveWrite;
 
 	// remove old vehicle from DB
 	[_objectID,_objectUID,_activatingPlayer] call server_deleteObj;
-	uiSleep 1;
 
 	// switch var to new vehicle at this point.
 	_object = _newobject;

--- a/SQF/dayz_server/compile/server_updateObject.sqf
+++ b/SQF/dayz_server/compile/server_updateObject.sqf
@@ -195,7 +195,7 @@ _object_killed = {
 	diag_log format["DELETE: Deleted by KEY: %1",_key];
 	#endif
 	
-	if (((typeOf _object) in DayZ_removableObjects) or ((typeOf _object) in DZE_isRemovable)) then {[_objectID,_objectUID] call server_deleteObj;};
+	if (((typeOf _object) in DayZ_removableObjects) or ((typeOf _object) in DZE_isRemovable)) then {[_objectID,_objectUID,"__SERVER__"] call server_deleteObj;};
 };
 
 _object_maintenance = {


### PR DESCRIPTION
server_publishVehicle3 first creates the vehicle in the database then
reads it back to see if it's successful, previously it wasn't deleting
the vehicle if it failed.

Added a 1 second delay after the vehicle delete to stop duping of
vehicles also.

Fixed references to server_deleteObj that were using 2 parameters
instead of the required 3 and updated the example.