### PR TITLE
Extend DZE_GodModeBase to newly built items

### DIFF
--- a/CHANGE LOG 1.0.6.1.txt
+++ b/CHANGE LOG 1.0.6.1.txt
@@ -88,6 +88,7 @@
 [FIXED] A potential undefined error on bear trap trigger. @oiad
 [FIXED] A few floating loot positions in firestation.
 [FIXED] Blocked a duping method involving changing clothes. Thanks to Sercan for reporting. @oiad
+[FIXED] Buildables now properly apply godmode if enabled during the restart window. @oiad
 
 [NOTE] The fixes below are included in the 1.0.6 Build C server package released December 29th, 2016 (http://dayzepoch.com/a2dayzepoch.php)
 [FIXED] Hive child 309 errors that resulted in broken saving of newly built storage object inventory. @icomrade

--- a/SQF/dayz_code/actions/modular_build.sqf
+++ b/SQF/dayz_code/actions/modular_build.sqf
@@ -588,6 +588,10 @@ if (_canBuild select 0) then {
 						publicVariableServer "PVDZ_obj_Publish";
 					};
 				};
+				if (DZE_GodModeBase && {!(_classname in DZE_GodModeBaseExclude)}) then {
+					_tmpbuilt addEventHandler ["HandleDamage",{false}];
+					_tmpbuilt enableSimulation false;
+				}; 
 			} else { //if magazine was not removed, cancel publish
 				deleteVehicle _tmpbuilt;
 				localize "str_epoch_player_46" call dayz_rollingMessages;

--- a/SQF/dayz_code/actions/player_build.sqf
+++ b/SQF/dayz_code/actions/player_build.sqf
@@ -469,6 +469,10 @@ if (_canBuild select 0) then {
 						publicVariableServer "PVDZ_obj_Publish";
 					};
 				};
+				if (DZE_GodModeBase && {!(_classname in DZE_GodModeBaseExclude)}) then {
+					_tmpbuilt addEventHandler ["HandleDamage",{false}];
+					_tmpbuilt enableSimulation false;
+				}; 
 			} else {
 				deleteVehicle _tmpbuilt;
 				localize "str_epoch_player_46" call dayz_rollingMessages;

--- a/SQF/dayz_code/actions/player_buildingDowngrade.sqf
+++ b/SQF/dayz_code/actions/player_buildingDowngrade.sqf
@@ -104,6 +104,11 @@ if ((count _upgrade) > 0) then {
 
 		format[localize "str_epoch_player_142",_text] call dayz_rollingMessages;
 
+		if (DZE_GodModeBase && {!(_classname in DZE_GodModeBaseExclude)}) then {
+			_object addEventHandler ["HandleDamage",{false}];
+			_object enableSimulation false;
+		};
+		
 		if (DZE_permanentPlot) then {
 			_ownerID = _obj getVariable["ownerPUID","0"];
 			_object setVariable ["ownerPUID",_ownerID,true];

--- a/SQF/dayz_code/actions/player_upgrade.sqf
+++ b/SQF/dayz_code/actions/player_upgrade.sqf
@@ -125,6 +125,10 @@ if ((count _upgrade) > 0) then {
 			} else {	
 				format[localize "str_epoch_player_159",_text] call dayz_rollingMessages;
 			};
+			if (DZE_GodModeBase && {!(_classname in DZE_GodModeBaseExclude)}) then {
+				_object addEventHandler ["HandleDamage",{false}];
+				_object enableSimulation false;
+			}; 
 			if (DZE_permanentPlot) then {
 				_ownerID = _obj getVariable["ownerPUID","0"];
 				if (_ownerID == "0") then { _ownerID = dayz_playerUID; }; //APFL is on but UID is 0 so we will claim it to record the ownership.

--- a/SQF/dayz_server/compile/server_publishObject.sqf
+++ b/SQF/dayz_server/compile/server_publishObject.sqf
@@ -23,7 +23,7 @@ if ([_object, "Server"] call check_publishobject) then {
 	_key call server_hiveWrite;
 
 	if !(_object isKindOf "TrapItems") then {
-		if (DZE_GodModeBase) then {
+		if (DZE_GodModeBase && {!(_type in DZE_GodModeBaseExclude)}) then {
 			_object addEventHandler ["HandleDamage", {false}];
 		} else {
 			_object addMPEventHandler ["MPKilled",{_this call vehicle_handleServerKilled;}];

--- a/SQF/dayz_server/compile/server_swapObject.sqf
+++ b/SQF/dayz_server/compile/server_swapObject.sqf
@@ -65,9 +65,9 @@ _key call server_hiveWrite;
 _object setVariable ["lastUpdate",time];
 _object setVariable ["ObjectUID", _uid,true];
 // _object setVariable ["CharacterID",_charID,true];
-if (DZE_GodModeBase) then {
-	_object addEventHandler ["HandleDamage", {false}];
-}else{
+if (DZE_GodModeBase && {!(_class in DZE_GodModeBaseExclude)}) then {
+	_object addEventHandler ["HandleDamage",{false}];
+} else {
 	_object addMPEventHandler ["MPKilled",{_this call vehicle_handleServerKilled;}];
 };
 // Test disabling simulation server side on buildables only.


### PR DESCRIPTION
This now makes buildables properly apply godmode instead of having to
wait till restart for:

* Being built
* Being upgraded
* Being downgraded