### PR TITLE
Convert DZE_SafeZoneNoBuildItems to handle nested arrays for custom d…

### DIFF
--- a/SQF/dayz_code/compile/dze_buildChecks.sqf
+++ b/SQF/dayz_code/compile/dze_buildChecks.sqf
@@ -106,7 +106,7 @@ _text = getText (configFile >> 'CfgMagazines' >> _item >> 'displayName');
 
 _buildCheck = call _checkClass;
 
-if (((count DZE_SafeZoneNoBuildItems) > 0) && (_buildCheck select 0)) then {
+if (_buildCheck select 0) then {
 	{
 		if ((player distance (_x select 0)) < _buildCheck select 1) exitWith {_canBuild = false;};
 	} count DZE_safeZonePosArray;

--- a/SQF/dayz_code/compile/dze_buildChecks.sqf
+++ b/SQF/dayz_code/compile/dze_buildChecks.sqf
@@ -21,10 +21,11 @@ _checkClass = {
 
 	{
 		if (typeName _x == "ARRAY") then {
-			if (_x select 0 == _classname) exitWith {_checkOK = true; _distance = _x select 1;};
+			if (_x select 0 == _classname) then {_checkOK = true; _distance = _x select 1;};
 		} else {
-			if (_x == _className) exitWith {_checkOK = true};
+			if (_x == _className) then {_checkOK = true};
 		};
+		if (_checkOK) exitWith {};
 	} count DZE_SafeZoneNoBuildItems;
 
 	[_checkOK,_distance]

--- a/SQF/dayz_code/configVariables.sqf
+++ b/SQF/dayz_code/configVariables.sqf
@@ -26,7 +26,7 @@ DZE_VanillaUICombatIcon = true; //Display or hide combat UI icon if using DZE_UI
 timezoneswitch = 0; // Changes murderMenu times with this offset in hours.
 DZE_NoVehicleExplosions = false; //Disable vehicle explosions to prevent damage to objects by ramming. Doesn't work with amphibious pook which should not be used due to FPS issues.
 DZE_SafeZonePosArray = []; //Prevent players in safeZones from being killed if their vehicle is destroyed. Format is [[[3D POS], RADIUS],[[3D POS], RADIUS]]; Ex. DZE_SafeZonePosArray = [[[6325.6772,7807.7412,0],150],[[4063.4226,11664.19,0],150]];
-DZE_SafeZoneNoBuildItems = []; // Array of object class names not allowed to build near the safe zones listed above. i.e ["VaultStorageLocked","LockboxStorageLocked","Plastic_Pole_EP1_DZ"] etc.
+DZE_SafeZoneNoBuildItems = []; // Array of object class names not allowed to be built near the safe zones listed above. Can be nested arrays for custom distances. i.e ["VaultStorageLocked","LockboxStorageLocked",["Plastic_Pole_EP1_DZ",1300]] etc.
 DZE_SafeZoneNoBuildDistance = 150; // Distance from safe zones listed above to disallow building near.
 DZE_NoBuildNear = []; //Array of object class names that are blacklisted to build near. i.e ["Land_Mil_ControlTower","Land_SS_hangar"] etc.
 DZE_NoBuildNearDistance = 150; // Distance from blacklisted objects to disallow building near.


### PR DESCRIPTION
…istances per items.

This makes the DZE_SafeZoneNoBuildItems be able to handle nested arrays,
This allows you to set custom distances per item instead of having it
all the default distance.

E.g DZE_SafeZoneNoBuildItems =
["VaultStorageLocked","LockboxStorageLocked",["Plastic_Pole_EP1_DZ",1300]];