### PR TITLE
Dont show you have the item if it's not nearby

### DIFF
--- a/SQF/dayz_code/actions/AdvancedTrading/functions/z_at_fillBuyableList.sqf
+++ b/SQF/dayz_code/actions/AdvancedTrading/functions/z_at_fillBuyableList.sqf
@@ -12,7 +12,7 @@ _typeOf = typeOf (unitBackPack player);
 	_type = _x select 1;
 	_count = 0;
 	
-	if (_type in DZE_tradeVehicle && {_name == typeOf DZE_myVehicle}) then {
+	if (_type in DZE_tradeVehicle && {_name == typeOf DZE_myVehicle} && {player distance DZE_myVehicle < Z_VehicleDistance}) then {
 		_count = 1;
 	};
 	if (_type == "trade_items") then {

--- a/SQF/dayz_code/actions/AdvancedTrading/functions/z_at_fillBuyableList.sqf
+++ b/SQF/dayz_code/actions/AdvancedTrading/functions/z_at_fillBuyableList.sqf
@@ -12,7 +12,7 @@ _typeOf = typeOf (unitBackPack player);
 	_type = _x select 1;
 	_count = 0;
 	
-	if (_type in DZE_tradeVehicle && {_name == typeOf DZE_myVehicle} && {player distance DZE_myVehicle < Z_VehicleDistance}) then {
+	if (_type in DZE_tradeVehicle && {_name == typeOf DZE_myVehicle} && {player distance DZE_myVehicle <= Z_VehicleDistance}) then {
 		_count = 1;
 	};
 	if (_type == "trade_items") then {


### PR DESCRIPTION
This was showing you had a vehicle in the trader menu even if it was
over the other side of the map, I think this works better only showing
it if it's within the trader zone.