### PR TITLE
Forbid removing the plot/door owner from objects

### DIFF
--- a/SQF/dayz_code/actions/doorManagement/doorRemoveFriend.sqf
+++ b/SQF/dayz_code/actions/doorManagement/doorRemoveFriend.sqf
@@ -4,6 +4,9 @@ _pos = _this select 0;
 if (_pos < 0) exitWith {};
 _friends = TheDoor getVariable ["doorfriends", []];
 _toRemove = (_friends select _pos);
+
+if ((_toRemove select 0) == ((_friends select 0) select 0) && (!(dayz_playerUID in DZE_doorManagementAdmins) && !(dayz_playerUID == ((_friends select 0) select 0)))) exitWith {systemChat localize "STR_EPOCH_DOORMANAGEMENT_CANT_REMOVE";};
+
 _newList = [];
 {
 	if(_x select 0  != _toRemove select 0) then {

--- a/SQF/dayz_code/actions/plotManagement/plotRemoveFriend.sqf
+++ b/SQF/dayz_code/actions/plotManagement/plotRemoveFriend.sqf
@@ -6,6 +6,9 @@ _plots = ([player] call FNC_getPos) nearEntities ["Plastic_Pole_EP1_DZ",15];
 _thePlot = _plots select 0;
 _friends = _thePlot getVariable ["plotfriends", []];
 _toRemove = (_friends select _pos);
+
+if ((_toRemove select 0) == ((_friends select 0) select 0) && (!(dayz_playerUID in DZE_PlotManagementAdmins) && !(dayz_playerUID == ((_friends select 0) select 0)))) exitWith {systemChat localize "STR_EPOCH_PLOTMANAGEMENT_CANT_REMOVE";};
+
 _newList = [];
 {
 	if (_x select 0  != _toRemove select 0) then {

--- a/SQF/dayz_code/stringtable.xml
+++ b/SQF/dayz_code/stringtable.xml
@@ -15533,6 +15533,9 @@
 			<Russian>Можно добавить друзей: %1</Russian>
 			<German>Nur %1 Freunde erlaubt.</German>
 		</Key>
+		<Key ID="STR_EPOCH_PLOTMANAGEMENT_CANT_REMOVE">
+			<English>You can't remove the plot owner.</English>
+		</Key>
 		<Key ID="STR_EPOCH_PLOTMANAGEMENT_SHOW_BOUNDARY">
 			<English>Show plot boundary</English>
 			<German>Zeige Grundstücksgrenze</German>
@@ -16898,7 +16901,10 @@
 			<German>Du darfst diese Tür nicht verwalten.</German>
 			<Russian>У вас нет прав доступа.</Russian>
 		</Key>
-		
+		<Key ID="STR_EPOCH_DOORMANAGEMENT_CANT_REMOVE">
+			<English>You can't remove the door owner.</English>
+		</Key>
+
 		<Key ID="STR_EPOCH_OPEN_RAMP">
 			<English>Open Ramp</English>
 			<German>Rampe öffnen</German>


### PR DESCRIPTION
This makes it so only the door or plot owner can remove them selves from
doors/plots or the UIDS in
DZE_PlotManagementAdmins/DZE_DoorManagementAdmins.