### PR TITLE
Fix Corepatch AS50 magazine spawn

### DIFF
--- a/CHANGE LOG 1.0.6.2.txt
+++ b/CHANGE LOG 1.0.6.2.txt
@@ -48,6 +48,7 @@
 [FIXED] Readded crossbow reload sound
 [FIXED] Using setDamage or setHit to kill a player via script will no longer cause a double death.
 [FIXED] The dramatic recoil camera shake effect from a nearby bullet hit is now reset correctly instead of remaining permanent.
+[FIXED] Added temporary fix for missing AS50 ammo error with beta branch core patch. #1955 @AirwavesMan
 
 [NOTE] Fixes below are included in the mission file and server pbo as part of server package 1.0.6.1A (March 10th 2017)
 [FIXED] Fixed food and drink going down 10x faster from melee and other "working" actions. 

--- a/SQF/dayz_code/Configs/CfgMagazines/Magazines/127x99.hpp
+++ b/SQF/dayz_code/Configs/CfgMagazines/Magazines/127x99.hpp
@@ -1,0 +1,5 @@
+class 5Rnd_127x99_as50;
+class 5Rnd_127x99_as50_CP : 5Rnd_127x99_as50
+{
+		ammo = "B_127x99_Ball_noTracer";
+};

--- a/SQF/dayz_code/Configs/CfgMagazines/Magazines/Magazines.hpp
+++ b/SQF/dayz_code/Configs/CfgMagazines/Magazines/Magazines.hpp
@@ -18,5 +18,6 @@
 #include "Shotgun.hpp"
 #include "Arrows.hpp"
 #include "LauncherAmmo.hpp"
+#include "127x99.hpp" //Remove after A2OA stable branch exceeds Version 1.63.131129
 
 #undef COMBINE_MAG

--- a/SQF/dayz_code/Configs/CfgWeapons/Weapon/Sniper/AS50.hpp
+++ b/SQF/dayz_code/Configs/CfgWeapons/Weapon/Sniper/AS50.hpp
@@ -1,8 +1,9 @@
 class BAF_AS50_scoped;
 class BAF_AS50_scoped_DZ : BAF_AS50_scoped {
-	displayname = "AS50_DZ";
+	displayname = "AS50";
 	type = WeaponSlotPrimary;
 	canlock = 0;
+	magazines[] = {"5Rnd_127x99_as50","10Rnd_127x99_m107","5Rnd_127x99_as50_CP"};
 	//cursor = "RifleCursor";
 	//cursoraim = "Foresight";
 };

--- a/SQF/dayz_code/Configs/CfgWeapons/Weapon/Sniper/AS50.hpp
+++ b/SQF/dayz_code/Configs/CfgWeapons/Weapon/Sniper/AS50.hpp
@@ -3,7 +3,6 @@ class BAF_AS50_scoped_DZ : BAF_AS50_scoped {
 	displayname = "AS50";
 	type = WeaponSlotPrimary;
 	canlock = 0;
-	magazines[] = {"5Rnd_127x99_as50","10Rnd_127x99_m107","5Rnd_127x99_as50_CP"};
 	//cursor = "RifleCursor";
 	//cursoraim = "Foresight";
 };


### PR DESCRIPTION
The Corepatch broke some of the AS50 magazine spawns. Im not sure why it happend sometimes and sometimes not.

This message showed up sometimes: No entry 'bin\config.bin/CfgMagazines-5Rnd_127x99_as50_CP'.

The CorePatch use that: 

https://github.com/Goliath86/CorePatch/blob/e0d06f7086fb0e3b3e6b7dc22beeca3b087967be/CorePatch_CIT_14888/config.cpp

This commit should fix that error message and the AS50 name as well.