### PR TITLE
Fix gut zombie not showing up reliably

### DIFF
--- a/SQF/dayz_code/actions/userActionConditions.sqf
+++ b/SQF/dayz_code/actions/userActionConditions.sqf
@@ -1,7 +1,7 @@
 #define CAN_DO (!r_drag_sqf && !r_player_unconscious && getNumber (configFile >> "CfgMovesMaleSdr" >> "States" >> (animationState player) >> "onLadder") != 1)
 #define HAS_TOOLBOX ("ItemToolbox" in items player)
 #define IN_VEHICLE (vehicle player != player)
-#define IS_ALIVE (damage _object < 1)
+#define IS_ALIVE (if (_object isKindOf "zZombie_Base") then {alive _object} else {damage _object < 1})
 #define IS_DAMAGED (damage _object > 0)
 #define IS_PZOMBIE (player isKindOf "PZombie_VB")
 


### PR DESCRIPTION
This fixes gut zombie not working correctly, using damage on a zombie to
check if alive only works if the zombie takes a large large hit. it
works great for checking  vehicles or objects but not zombies/players,
need to use alive in this situation.

Thanks to @theduke for the heads up.