### PR TITLE
extend epoch_tempKeys to return key classnames also

### DIFF
--- a/SQF/dayz_code/compile/epoch_tempKeys.sqf
+++ b/SQF/dayz_code/compile/epoch_tempKeys.sqf
@@ -1,13 +1,14 @@
 /*
 	To return array of keys on the players toolbelt and inside a (valid) backpack:
 	_result = call epoch_tempKeys;
-	Returns array: [["11148","1457"],["Black Key (2eb5)","Green Key (9c30)"]]
+	Returns array: [["11148","1457"],["Black Key (2eb5)","Green Key (9c30)"],["ItemKeyBlack1148","ItemKeyGreen1457"]]
 */
 
-private ["_temp_keys","_temp_keys_names","_key_colors","_ownerKeyId","_ownerKeyName","_items"];
+private ["_temp_keys","_temp_keys_names","_key_colors","_ownerKeyId","_ownerKeyName","_items","_temp_keys_class"];
 
 _temp_keys = [];
 _temp_keys_names = [];
+_temp_keys_class = [];
 _items = items player;
 dayz_myBackpack = unitBackpack player;
 
@@ -23,7 +24,8 @@ _key_colors = ["ItemKeyYellow","ItemKeyBlue","ItemKeyRed","ItemKeyGreen","ItemKe
 		_ownerKeyName = getText(configFile >> "CfgWeapons" >> _x >> "displayName");
 		_temp_keys_names set [count _temp_keys_names,_ownerKeyName];
 		_temp_keys set [count _temp_keys,str _ownerKeyId];
+		_temp_keys_class set [count _temp_keys_class,_x];
 	};
 } count _items;
 
-[_temp_keys,_temp_keys_names]
+[_temp_keys,_temp_keys_names,_temp_keys_class]


### PR DESCRIPTION
Useful for mods that require key functionality (vkc, virtual garage etc)