### PR TITLE
AI hit messages and continuity

### DIFF
--- a/SQF/dayz_code/compile/fn_damageHandler.sqf
+++ b/SQF/dayz_code/compile/fn_damageHandler.sqf
@@ -171,7 +171,7 @@ if (_unit == player) then {
 		_sourceDist = round(_unit distance _source);
 		_sourceWeap = switch (true) do {
 			case (_ammo in ["PipeBomb","Mine","MineE"]): { format["with %1",_ammo] };
-			case (_isVehicle) : { format ["in %1",getText(configFile >> "CfgVehicles" >> _sourceVehicleType >> "displayName")] };
+			case (_isVehicle) : { format ["with a %1",getText(configFile >> "CfgVehicles" >> _sourceVehicleType >> "displayName")] };
 			case (_ammo in MeleeAmmo) : { format ["with %2%1",_wpst select 0, if (_sourceDist>6) then {"suspicious weapon "} else {""}] };
 			case (_wpst select 0 == "Throw") : { format ["with %1 thrown", _wpst select 3] };
 			case (["Horn", currentWeapon _source] call fnc_inString) : {"with suspicious vehicle "+str((getposATL _source) nearEntities [["Air", "LandVehicle", "Ship"],5])};

--- a/SQF/dayz_server/compile/server_publishVehicle3.sqf
+++ b/SQF/dayz_server/compile/server_publishVehicle3.sqf
@@ -45,7 +45,7 @@ _key call server_hiveWrite;
    _class = _this select 3;
    _dir = _this select 4;
    // _location = _this select 5;
-   _location = [_object] call fnc_getPos;
+   _location = getPosATL _object;
    _donotusekey = _this select 6;
    _activatingPlayer = _this select 7;
 
@@ -111,7 +111,6 @@ _key call server_hiveWrite;
 
 	_object setDir _dir;
 	_object setPosATL _location;
-	_object setVectorUp surfaceNormal _location;
 						
 	//Add weapons
 	_objWpnTypes = 	_weapons select 0;

--- a/SQF/dayz_server/compile/server_publishVehicle3.sqf
+++ b/SQF/dayz_server/compile/server_publishVehicle3.sqf
@@ -45,7 +45,7 @@ _key call server_hiveWrite;
    _class = _this select 3;
    _dir = _this select 4;
    // _location = _this select 5;
-   _location = getPosATL _object;
+   _location = [_object] call fnc_getPos;
    _donotusekey = _this select 6;
    _activatingPlayer = _this select 7;
 
@@ -111,6 +111,7 @@ _key call server_hiveWrite;
 
 	_object setDir _dir;
 	_object setPosATL _location;
+	_object setVectorUp surfaceNormal _location;
 						
 	//Add weapons
 	_objWpnTypes = 	_weapons select 0;

--- a/SQF/dayz_server/init/server_functions.sqf
+++ b/SQF/dayz_server/init/server_functions.sqf
@@ -250,7 +250,7 @@ fa_plr2str = {
 		_name = _x getVariable ["bodyName", nil];
 		if ((isNil "_name" OR {(_name == "")}) AND ({alive _x})) then { _name = name _x; };
 		if (isNil "_name" OR {(_name == "")}) then { _name = "UID#"+(getPlayerUID _x); };
-		_res = format["PID#%1(%2)", owner _x, _name ];
+		_res = if (isPlayer _x) then {format["PID#%1(%2)", owner _x, _name]} else {localize "STR_PLAYER_AI"};
 	};
 	_res
 };


### PR DESCRIPTION
This changes the hit messages to only show AI instead of the AI's names.
Changes this:
```
20:08:37 "P1ayer PID#7(salival) hit by PID#1(Qadeer Hakimi) with
vil_G36VA4Eot/B_556x45_Ball <ammo left:25> from 356 meters in head_hit
for 0 damage"
```
To this:
```
20:08:37 "P1ayer PID#7(salival) hit by AI with
vil_G36VA4Eot/B_556x45_Ball <ammo left:25> from 356 meters in head_hit
for 0 damage"
```

Continuity fix for hit and kill for vehicles so they match:
Before:
```
22:44:03 "P1ayer PID#3(salival) hit by AI in Pickup (PK) DZ from 15
meters in head_hit for 0.88666 damage"
```
After:
```
22:44:03 "P1ayer PID#3(salival) hit by AI with a Pickup (PK) DZ from 15
meters in head_hit for 0.88666 damage"
```
Kill message:
```
22:44:04 "salival (76561197999617086) salival was killed
by AI with a Pickup_PK_INS_DZ from 15m"
```