### PR TITLE
Fix vehicles bouncing when upgrading.

### DIFF
--- a/SQF/dayz_server/compile/server_publishVehicle3.sqf
+++ b/SQF/dayz_server/compile/server_publishVehicle3.sqf
@@ -45,7 +45,7 @@ _key call server_hiveWrite;
    _class = _this select 3;
    _dir = _this select 4;
    // _location = _this select 5;
-   _location = getPosATL _object;
+   _location = [_object] call fnc_getPos;
    _donotusekey = _this select 6;
    _activatingPlayer = _this select 7;
 
@@ -111,6 +111,7 @@ _key call server_hiveWrite;
 
 	_object setDir _dir;
 	_object setPosATL _location;
+	_object setVectorUp surfaceNormal _location;
 						
 	//Add weapons
 	_objWpnTypes = 	_weapons select 0;


### PR DESCRIPTION
This helps stop vehicles bouncing when being upgraded.
The Vehicle Key Changer script I rewrote uses the epoch vehicle upgrade system to claim/change the vehicle key, we noticed that it was causing the vehicles to bounce, but VKC uses all the position functions from the epoch script so it's not something that VKC has introduced.