### PR TITLE
Force vehicle selling only from gear.

### DIFF
--- a/SQF/dayz_code/actions/AdvancedTrading/functions/z_at_checkArrayInConfig.sqf
+++ b/SQF/dayz_code/actions/AdvancedTrading/functions/z_at_checkArrayInConfig.sqf
@@ -105,7 +105,7 @@ _totalPrice = 0;
 					_HasKey = [DZE_myVehicle, _all] call _HasKeyCheck;
 				};
 			};
-			if (!_HasKey) exitWith {};
+			if (!_HasKey || {_y == _myVehType && Z_SellingFrom != 2}) exitWith {};
 
 			_worth = 0;
 			_currencyQty = _buy select 0;


### PR DESCRIPTION
This forces the player to only be able to sell a vehicle from the gear menu instead of backpack and vehicle menu since most of the time you would be using add all.

From: https://epochmod.com/forum/topic/44413-prevent-selling-vehicles-from-backpack/?tab=comments#comment-297328