### PR TITLE
Dont show incomplete lockbox code

### DIFF
--- a/SQF/dayz_server/compile/server_handleSafeGear.sqf
+++ b/SQF/dayz_server/compile/server_handleSafeGear.sqf
@@ -124,7 +124,7 @@ _fnc_lockCode = {
 	if (_code < 10000) exitWith {0};
 	_color = "";
 	_code = _code - 10000;
-	
+
 	if (_code <= 99) then {_color = localize "STR_TEAM_RED";};
 	if (_code >= 100 && _code <= 199) then {_color = localize "STR_TEAM_GREEN"; _code = _code - 100;};
 	if (_code >= 200) then {_color = localize "STR_TEAM_BLUE"; _code = _code - 200;};

--- a/SQF/dayz_server/compile/server_handleSafeGear.sqf
+++ b/SQF/dayz_server/compile/server_handleSafeGear.sqf
@@ -121,7 +121,7 @@ _fnc_lockCode = {
 
 	if (_this == "") exitWith {0};
 	_code = if (typeName _this == "STRING") then {parseNumber _this} else {_this};
-	if (_code < 10000) exitWith {0};
+	if (_code < 10000 || {_code > 10299}) exitWith {0};
 	_color = "";
 	_code = _code - 10000;
 

--- a/SQF/dayz_server/compile/server_handleSafeGear.sqf
+++ b/SQF/dayz_server/compile/server_handleSafeGear.sqf
@@ -120,8 +120,9 @@ _fnc_lockCode = {
 	private ["_color","_code"];
 
 	if (_this == "") exitWith {0};
-	_color = "";
 	_code = if (typeName _this == "STRING") then {parseNumber _this} else {_this};
+	if (_code < 10000) exitWith {0};
+	_color = "";
 	_code = _code - 10000;
 	
 	if (_code <= 99) then {_color = localize "STR_TEAM_RED";};
@@ -129,7 +130,7 @@ _fnc_lockCode = {
 	if (_code >= 200) then {_color = localize "STR_TEAM_BLUE"; _code = _code - 200;};
 	if (_code <= 9) then {_code = format["0%1", _code];};
 	_code = format ["%1%2",_color,_code];
-	
+
 	_code
 };
 


### PR DESCRIPTION
If the player enters a wrong code the algorithm can make the entered code seem completely bogus, let's just exit out of the routine if that's the case.

Sample bad code (Just hit red key):
```11:45:54 "salival (playerUID) FAILED unlocking LockBox with code: Red0-9900 (actual: Red34) @038117 [3899.36,3580.24,1.632]"```