### PR TITLE
Fix javelin/stinger selling

### DIFF
--- a/SQF/dayz_code/actions/AdvancedTrading/functions/z_at_checkArrayInConfig.sqf
+++ b/SQF/dayz_code/actions/AdvancedTrading/functions/z_at_checkArrayInConfig.sqf
@@ -19,114 +19,113 @@ _vehTrade = false;
 _baseVehicle = "";
 _myVehType = typeOf DZE_myVehicle;
 
-if (false call Z_checkCloseVehicle) then {
-	_baseVehicle = getText (configFile >> "CfgVehicles" >> _myVehType >> "original");
-	_all = _weaps + _mags + _bags + [_myVehType];
-	_vehTrade = true;
-} else {
-	_all = _weaps + _mags + _bags;
-};
-
 _arrayOfTraderCat = Z_traderData;
 _HasKeyCheck = {
-	_obj = _this select 0;
-	_inventory = _this select 1;
+	private ["_objectCharacterID","_keyFound","_tempKeys"];
+
 	_keyFound = false;
-	_objectCharacterId	= _obj getVariable ["CharacterID","0"];
+	_objectCharacterId	= DZE_myVehicle getVariable ["CharacterID","0"];
 	if (_objectCharacterId == "0") then {
 		_keyFound = true;
 	} else {
-		_keyColor = ["ItemKeyYellow","ItemKeyBlue","ItemKeyRed","ItemKeyGreen","ItemKeyBlack"];
-		{
-			if (configName(inheritsFrom(configFile >> "CfgWeapons" >> _x)) in _keyColor) then {
-				if (str(getNumber(configFile >> "CfgWeapons" >> _x >> "keyid")) == _objectCharacterId) then {
-					_keyFound = true;
-				};
-			};
-		} count _inventory;
+		_tempKeys = call epoch_tempKeys;
+		if (((_tempKeys select 0) find _objectCharacterID) >= 0) then {_keyFound = true;};
 	};
+
 	_keyFound;
 };
 _totalPrice = 0;
 
-{
-	_y = _x;
-	_swap = false;
-	_swap2 = false;
-	if (_y == "ItemBloodbag" && dayz_classicBloodBagSystem) then {
-		_y = "bloodBagONEG";
-		_swap = true;
-	};
-	if (_y == _myVehType && {_baseVehicle != ""}) then {
-		_swap2 = true;
-	};
+_processGear = {
+	private ["_array","_type","_cat","_exists","_pic","_text","_sell","_buy","_buyCurrency","_sellCurrency","_worth"];
+
+	_type = _this select 1;
 	{
-		private ["_cat","_exists","_pic","_text","_type","_sell","_buy","_buyCurrency","_sellCurrency","_worth"];
-		_cat =  format["Category_%1",(_arrayOfTraderCat select _forEachIndex select 1)];
-		if (isNumber (missionConfigFile >> "CfgTraderCategory" >> _cat >> "duplicate")) then {
-			_cat = format["Category_%1",getNumber (missionConfigFile >> "CfgTraderCategory" >> _cat >> "duplicate")];
+		_y = _x;
+		_swap = false;
+		_swap2 = false;
+		if (_y == "ItemBloodbag" && dayz_classicBloodBagSystem) then {
+			_y = "bloodBagONEG";
+			_swap = true;
 		};
-		if (_swap2 && {!isClass(missionConfigFile >> "CfgTraderCategory"  >> _cat >> _y)} && {isClass(missionConfigFile >> "CfgTraderCategory"  >> _cat >> _baseVehicle)}) then {
-			//Use base vehicle prices for upgraded _DZE[1-4] variants only if they are not explicitly added in trader config
-			_y = _baseVehicle;
+		if (_y == _myVehType && {_baseVehicle != ""}) then {
+			_swap2 = true;
 		};
-		_exists = isClass(missionConfigFile >> "CfgTraderCategory"  >> _cat >> _y);
-		if (_exists) exitWith {
-			_pic = "";
-			_text = "";
-			_type = getText(missionConfigFile >> "CfgTraderCategory"  >> _cat  >> _y >> "type");
-			// Make sure type matches for items that have the same weapon and magazine classname (i.e. PipeBomb, Mine, Javelin, etc.)
-			if ((_type == "trade_items" && !(_y in _mags) && !_swap) or (_type == "trade_weapons" && !(_y in _weaps))) exitWith {};
-			_sell = getArray(missionConfigFile >> "CfgTraderCategory"  >> _cat  >> _y >> "sell");
-			_buy = getArray(missionConfigFile >> "CfgTraderCategory"  >> _cat  >> _y >> "buy");
-			if (_swap) then {_y = "ItemBloodbag"};
-			switch (true) do {
-				case (_type == "trade_items") :
-				{
-					_pic = getText (configFile >> 'CfgMagazines' >> _y >> 'picture');
-					_text = getText (configFile >> 'CfgMagazines' >> _y >> 'displayName');
-				};
-				case (_type == "trade_weapons") :
-				{
-					_pic = getText (configFile >> 'CfgWeapons' >> _y >> 'picture');
-					_text = getText (configFile >> 'CfgWeapons' >> _y >> 'displayName');
-				};
-				case (_type in DZE_tradeObject) :
-				{
-					_pic = getText (configFile >> 'CfgVehicles' >> _y >> 'picture');
-					_text = getText (configFile >> 'CfgVehicles' >> _y >> 'displayName');
-				};
+		{
+			_cat =  format["Category_%1",(_arrayOfTraderCat select _forEachIndex select 1)];
+			if (isNumber (missionConfigFile >> "CfgTraderCategory" >> _cat >> "duplicate")) then {
+				_cat = format["Category_%1",getNumber (missionConfigFile >> "CfgTraderCategory" >> _cat >> "duplicate")];
 			};
+			if (_swap2 && {!isClass(missionConfigFile >> "CfgTraderCategory"  >> _cat >> _y)} && {isClass(missionConfigFile >> "CfgTraderCategory"  >> _cat >> _baseVehicle)}) then {
+				//Use base vehicle prices for upgraded _DZE[1-4] variants only if they are not explicitly added in trader config
+				_y = _baseVehicle;
+			};
+			_exists = isClass(missionConfigFile >> "CfgTraderCategory"  >> _cat >> _y);
+			if (_exists) exitWith {
+				_pic = "";
+				_text = "";
 
-			if (isNil '_text') then { _text = _y; };
-			_HasKey = true;
-			if (_vehTrade && {_y == _myVehType}) then {
-				if (!(_type in DZE_tradeVehicleKeyless) && DZE_SaleRequiresKey) then {
-					_HasKey = [DZE_myVehicle, _all] call _HasKeyCheck;
+				_sell = getArray(missionConfigFile >> "CfgTraderCategory"  >> _cat  >> _y >> "sell");
+				_buy = getArray(missionConfigFile >> "CfgTraderCategory"  >> _cat  >> _y >> "buy");
+				if (_swap) then {_y = "ItemBloodbag"};
+				switch (true) do {
+					case (_type == "trade_items") :
+					{
+						_pic = getText (configFile >> 'CfgMagazines' >> _y >> 'picture');
+						_text = getText (configFile >> 'CfgMagazines' >> _y >> 'displayName');
+					};
+					case (_type == "trade_weapons") :
+					{
+						_pic = getText (configFile >> 'CfgWeapons' >> _y >> 'picture');
+						_text = getText (configFile >> 'CfgWeapons' >> _y >> 'displayName');
+					};
+					case (_type in DZE_tradeObject) :
+					{
+						_pic = getText (configFile >> 'CfgVehicles' >> _y >> 'picture');
+						_text = getText (configFile >> 'CfgVehicles' >> _y >> 'displayName');
+					};
 				};
-			};
-			if (!_HasKey) exitWith {};
 
-			_worth = 0;
-			_currencyQty = _buy select 0;
-			if (!Z_SingleCurrency) then {
-				_buyCurrency = 	_buy select 1;
-				_sellCurrency = _sell select 1;
-				_part =  (configFile >> "CfgMagazines" >> _sellCurrency);
-				_worth =  getNumber(_part >> "worth");
-				if (_worth == 0) then { _worth = DZE_GemWorthList select (DZE_GemList find _buyCurrency); };
-			} else {
-				_buyCurrency = CurrencyName;
-				_sellCurrency = CurrencyName;
+				if (isNil '_text') then { _text = _y; };
+				_HasKey = true;
+				if (_vehTrade && {_y == _myVehType}) then {
+					if (!(_type in DZE_tradeVehicleKeyless) && DZE_SaleRequiresKey) then {
+						_HasKey = call _HasKeyCheck;
+					};
+				};
+				if (!_HasKey || {_y == _myVehType && Z_SellingFrom != 2}) exitWith {};
+
+				_worth = 0;
+				_currencyQty = _buy select 0;
+				if (!Z_SingleCurrency) then {
+					_buyCurrency = 	_buy select 1;
+					_sellCurrency = _sell select 1;
+					_part = (configFile >> "CfgMagazines" >> _sellCurrency);
+					_worth = getNumber(_part >> "worth");
+					if (_worth == 0) then { _worth = DZE_GemWorthList select (DZE_GemList find _buyCurrency); };
+				} else {
+					_buyCurrency = CurrencyName;
+					_sellCurrency = CurrencyName;
+				};
+				if (_currencyQty < 0) then {_buyCurrency = localize "STR_EPOCH_UNAVAILABLE";};
+				if ((_sell select 0) >= 0) then {
+					Z_SellableArray set [count(Z_SellableArray) , [_y, _type, _sell select 0, _text, _pic, _forEachIndex, _currencyQty, _sellCurrency, _buyCurrency, 0 ,_cat, _worth]];
+				};
+				_totalPrice = _totalPrice + (_sell select 0);
 			};
-			if (_currencyQty < 0) then {_buyCurrency = localize "STR_EPOCH_UNAVAILABLE";};
-			if ((_sell select 0) >= 0) then {
-				Z_SellableArray set [count(Z_SellableArray) , [_y, _type, _sell select 0, _text, _pic, _forEachIndex, _currencyQty, _sellCurrency, _buyCurrency, 0 ,_cat, _worth]];
-			};
-			_totalPrice = _totalPrice + (_sell select 0);
-		};
-	} forEach _arrayOfTraderCat;
-} count _all;
+		} forEach _arrayOfTraderCat;
+	} count (_this select 0);
+};
+
+if (false call Z_checkCloseVehicle) then {
+	_baseVehicle = getText (configFile >> "CfgVehicles" >> _myVehType >> "original");
+	_vehTrade = true;
+	[[_myVehType],"trade_any_vehicle"] call _processGear;
+};
+
+[_weaps,"trade_weapons"] call _processGear;
+[_mags,"trade_items"] call _processGear;
+[_bags,"trade_backpacks"] call _processGear;
 
 Z_OriginalSellableArray = [] + Z_SellableArray;
 


### PR DESCRIPTION
The previous fix https://github.com/EpochModTeam/DayZ-Epoch/commit/4fa36dfd94b0bbfc63a14bb28035a692101dd1b1 was not working correctly, if you had say the a stinger launcher and a stinger ammo it would detect them both as weapons, this properly classifies them and all others as how they should be.

Moved to use epoch_tempKeys also

This forces the player to only be able to sell a vehicle from the gear menu instead of backpack and vehicle menu since most of the time you would be using add all.

From: https://epochmod.com/forum/topic/44413-prevent-selling-vehicles-from-backpack/?tab=comments#comment-297328