### PR TITLE
Allow modular buildables to refund defined parts

### DIFF
--- a/CHANGE LOG 1.0.6.2.txt
+++ b/CHANGE LOG 1.0.6.2.txt
@@ -4,6 +4,7 @@
 [NEW] The journal and dayz_survived variable now contain actual play time [array] instead of days since the character was created [number].
 [NEW] Added secondary iron sight to CZ550 and bolt animations to CZ550 and LeeEnfield by @Streatman
 [NEW] Added some basic compatibility for falconsan's Ruegen map (beta version released February 2016)
+[NEW] Admins can now define what parts are returned from modular building parts, see configVariables.sqf/DZE_modularConfig @oiad @BigEgg
 
 [UPDATED] Zombie pathing. Zeds should now run more direct to players.
 [UPDATED] The RIS attachment can be removed from the SA58_RIS_DZ now. @LunaCB

--- a/SQF/dayz_code/actions/remove.sqf
+++ b/SQF/dayz_code/actions/remove.sqf
@@ -22,7 +22,7 @@ if (DZE_permanentPlot) then {
 };
 
 if (_obj getVariable ["GeneratorRunning", false]) exitWith {dayz_actionInProgress = false; localize "str_epoch_player_89" call dayz_rollingMessages;};
-	
+
 _objectID 	= _obj getVariable ["ObjectID","0"];
 _objectUID	= _obj getVariable ["ObjectUID","0"];
 
@@ -71,7 +71,7 @@ _nameVehicle = getText(configFile >> "CfgVehicles" >> _objType >> "displayName")
 
 format[localize "str_epoch_player_162",_nameVehicle] call dayz_rollingMessages;
 
-if (_isModular) then {
+if (_isModular && {_objType in _x} count DZE_modularConfig == 0) then {
      localize "STR_EPOCH_ACTIONS_21" call dayz_rollingMessages;
 };
 
@@ -138,7 +138,7 @@ if (_brokenTool) then {
 	} else {
 		if (([player,_removeTool,1] call BIS_fnc_invRemove) > 0) then {_success = true;};
 	};
-	
+
 	if (_success) then {
 		format[localize "str_epoch_player_164",getText(configFile >> "CfgWeapons" >> _removeTool >> "displayName"),_nameVehicle] call dayz_rollingMessages;
 	};
@@ -190,14 +190,27 @@ if (_proceed && _success) then {
 					default {_selectedRemoveOutput = getArray (configFile >> "CfgVehicles" >> _objType >> "removeoutput")};
 				};
 			} else {
-				_selectedRemoveOutput = getArray (configFile >> "CfgVehicles" >> _objType >> "removeoutput");
+				if ({_objType in _x} count DZE_modularConfig > 0) then {
+					{
+						private ["_class", "_refund"];
+						
+						_class = _x select 0;
+						_refund = _x select 1;
+						
+						if (_objType == _class) then {
+							{_selectedRemoveOutput set [count _selectedRemoveOutput,_x];} forEach _refund;
+						};
+					} count DZE_modularConfig;
+				} else {
+					_selectedRemoveOutput = getArray (configFile >> "CfgVehicles" >> _objType >> "removeoutput");
+				};
 				_preventRefund = (_objectID == "0" && _objectUID == "0");
 
 			};
 		};
 
 		if ((count _selectedRemoveOutput) <= 0) then {
-			localize "str_epoch_player_90" call dayz_rollingMessages;
+			[localize "str_epoch_player_90",1] call dayz_rollingMessages;
 		};
 
 		if (_ipos select 2 < 0) then {

--- a/SQF/dayz_code/actions/remove.sqf
+++ b/SQF/dayz_code/actions/remove.sqf
@@ -227,9 +227,7 @@ if (_proceed && _success) then {
 					_gems set [(count _gems), (_x select 0)];
 					_weights set [(count _weights), (_x select 1)];
 				} count DZE_GemOccurance;
-				diag_log [_gems, _weights];
 				_gemSelected = [_gems, _weights] call BIS_fnc_selectRandomWeighted;
-				diag_log _gemSelected;
 				_selectedRemoveOutput set [(count _selectedRemoveOutput),[_gemSelected,1]];
 			};
 		};

--- a/SQF/dayz_code/actions/remove.sqf
+++ b/SQF/dayz_code/actions/remove.sqf
@@ -241,7 +241,7 @@ if (_proceed && _success) then {
 				_itemOut = _x select 0;
 				_countOut = _x select 1;
 				if (typeName _countOut == "ARRAY") then {
-					_countOut = round((random (_countOut select 1)) + (_countOut select 0));
+					_countOut = round((random (_countOut select 1)) max (_countOut select 0));
 				};
 				if (count _x > 2) then {
 					switch (_x select 2) do {

--- a/SQF/dayz_code/configVariables.sqf
+++ b/SQF/dayz_code/configVariables.sqf
@@ -93,6 +93,21 @@ DZE_dirWithDegrees = true; // When rotating objects with Q&E, use the custom deg
 DZE_buildMaxMoveDistance = 10; // Max distance player can walk from start position when building. Anything >= the differnce between DZE_PlotPole values is not recommended (allows walking into other plots).
 DZE_buildMaxHeightDistance = 10; // Max distance player can raise or lower object from start position when building.
 
+DZE_modularConfig = [];
+/*
+	Array of classnames with magazine based loot to be refunded on deconstruction of modular built items that do not typically refund.
+
+	For example:
+	DZE_modularConfig = [
+		["CinderWall_DZ", [["CinderBlocks",7],["MortarBucket",2]]],
+		["CinderWallDoor_DZ", [["CinderBlocks",7],["MortarBucket",2],["ItemTankTrap",3],["ItemPole",[1,3]]]]
+	];
+
+	This would refund 7 cinder blocks and 2 mortar for "CinderWall_DZ"
+	For "CinderWallDoor_DZ" you would get 7 cinder blocks, 2 mortar, 3 tank traps and a random number of poles between 1 and 3.
+	The refund amount can be an array where the first param is the minimum and the second is the maximum, it will refund a random amount between them.
+*/
+
 // Door Management
 DZE_doorManagement = true; // Enable Door Management by @DevZupa. 
 DZE_doorManagementMustBeClose = false; //Players must be within 10m of door to be added as a door friend.


### PR DESCRIPTION
This allows typically not refunded modular buildables to be configured by the server admin.

	For example:
	DZE_modularConfig = [
		["CinderWall_DZ", [["CinderBlocks",7],["MortarBucket",2]]],
		["CinderWallDoor_DZ", [["CinderBlocks",7],["MortarBucket",2],["ItemTankTrap",3],["ItemPole",[1,3]]]]
	];

	This would refund 7 cinder blocks and 2 mortar for "CinderWall_DZ"
	For "CinderWallDoor_DZ" you would get 7 cinder blocks, 2 mortar, 3 tank traps and a random number of poles between 1 and 3.
	The refund amount can be an array where the first param is the minimum and the second is the maximum, it will refund a random amount between them.

Thanks to @BigEgg17 for the suggestion and sample code.