### PR TITLE
Fix completely broken dze_buildChecks

### DIFF
--- a/SQF/dayz_code/compile/dze_buildChecks.sqf
+++ b/SQF/dayz_code/compile/dze_buildChecks.sqf
@@ -62,6 +62,8 @@ if (_isPole && {_IsNearPlot > 0}) exitWith {dayz_actionInProgress = false; forma
 
 if (_hasPole) exitWith {dayz_actionInProgress = false; localize "STR_EPOCH_PLAYER_133" call dayz_rollingMessages; [_canBuild, _isPole];};
 
+if (dayz_playerUID in DZE_PlotManagementAdmins) exitWith {dayz_actionInProgress = false; [true,_isPole];};
+
 if (_IsNearPlot == 0) then {
 	if (_requireplot == 0 || {_isLandFireDZ}) then {
 		_canBuild = true;
@@ -102,24 +104,24 @@ _buildables = DZE_maintainClasses + DZE_LockableStorage + ["DZ_buildables","DZ_s
 _center = if (isNull _nearestPole) then {_pos} else {_nearestPole};
 if ((count (nearestObjects [_center,_buildables,_distance])) >= DZE_BuildingLimit) exitWith {dayz_actionInProgress = false; format[localize "str_epoch_player_41",_distance] call dayz_rollingMessages; [false, _isPole];};
 
-if !(dayz_playerUID in DZE_PlotManagementAdmins) then {
-	_text = getText (configFile >> 'CfgMagazines' >> _item >> 'displayName');
+_text = getText (configFile >> 'CfgMagazines' >> _item >> 'displayName');
 
-	_buildCheck = call _checkClass;
+_buildCheck = call _checkClass;
 
-	if (_buildCheck select 0) then {
-		_canBuild = !((getPosATL player) call DZE_SafeZonePosCheck);
-	};
-
-	if !(_canBuild) exitWith {dayz_actionInProgress = false; format [localize "STR_EPOCH_PLAYER_166",_text,_buildCheck select 1] call dayz_rollingMessages; [false, _isPole];};
-
-	if ((count DZE_NoBuildNear) > 0) then {
-		_near = (nearestObjects [_pos,DZE_NoBuildNear,DZE_NoBuildNearDistance]);
-		if ((count _near) > 0) then { _canBuild = false; };
-	};
-
-	if !(_canBuild) exitWith {dayz_actionInProgress = false; format [localize "STR_EPOCH_PLAYER_167",_text,DZE_NoBuildNearDistance,typeOf (_near select 0)] call dayz_rollingMessages; [false, _isPole];};
+if (_buildCheck select 0) then {
+	{
+		if ((player distance (_x select 0)) < _buildCheck select 1) exitWith {_canBuild = false;};
+	} count DZE_safeZonePosArray;
 };
+
+if !(_canBuild) exitWith {dayz_actionInProgress = false; format [localize "STR_EPOCH_PLAYER_166",_text,_buildCheck select 1] call dayz_rollingMessages; [false, _isPole];};
+
+if ((count DZE_NoBuildNear) > 0) then {
+	_near = (nearestObjects [_pos,DZE_NoBuildNear,DZE_NoBuildNearDistance]);
+	if ((count _near) > 0) then { _canBuild = false; };
+};
+
+if !(_canBuild) exitWith {dayz_actionInProgress = false; format [localize "STR_EPOCH_PLAYER_167",_text,DZE_NoBuildNearDistance,typeOf (_near select 0)] call dayz_rollingMessages; [false, _isPole];};
 
 if (_toolCheck) then {
 	_require =  getArray (configFile >> "cfgMagazines" >> _item >> "ItemActions" >> "Build" >> "require");


### PR DESCRIPTION
Revert https://github.com/EpochModTeam/DayZ-Epoch/commit/d750f576eda3949f365b2fc97316b4faec7327d7 since it's using the wrong distance check (_buildCheck select 1 is needed for the nested array check)
Revert https://github.com/EpochModTeam/DayZ-Epoch/commit/bbb7da7c3c6572e1591189600ef55bf8b7eb2d71#diff-0cdf3d56b40b62e92b498e7362874f34 I broke this so that it would never properly exit, it's now done properly