### PR TITLE
Fix issues with DZE_limitPlots

### DIFF
--- a/SQF/dayz_code/actions/plotManagement/plotRemoveFriend.sqf
+++ b/SQF/dayz_code/actions/plotManagement/plotRemoveFriend.sqf
@@ -1,4 +1,4 @@
-private ["_pos","_plots","_thePlot","_friends","_toRemove","_newList"];
+private ["_pos","_plots","_thePlot","_friends","_toRemove","_newList","_hasPole"];
 
 _pos = _this select 0;
 if (_pos < 0) exitWith {};
@@ -6,13 +6,24 @@ _plots = ([player] call FNC_getPos) nearEntities ["Plastic_Pole_EP1_DZ",15];
 _thePlot = _plots select 0;
 _friends = _thePlot getVariable ["plotfriends", []];
 _toRemove = (_friends select _pos);
+_hasPole = false;
+_newList = [];
 
 if ((_toRemove select 0) == ((_friends select 0) select 0) && (!(dayz_playerUID in DZE_PlotManagementAdmins) && !(dayz_playerUID == ((_friends select 0) select 0)))) exitWith {systemChat localize "STR_EPOCH_PLOTMANAGEMENT_CANT_REMOVE";};
 
-_newList = [];
+if (DZE_limitPlots && {!(dayz_playerUID in DZE_PlotManagementAdmins)}) then {
+	{
+		if (_x getVariable["ownerPUID","0"] == dayz_playerUID || (_x getVariable["CharacterID","0"] == dayz_characterID) || ((((_x getVariable ["plotfriends",[]]) select 0) select 0) == dayz_playerUID) && (_x != _thePlot)) exitWith {
+			_hasPole = true;
+		};
+	} count (entities "Plastic_Pole_EP1_DZ");
+};
+
+if (_hasPole) exitWith {systemChat localize "STR_EPOCH_PLAYER_133";};
+
 {
-	if (_x select 0  != _toRemove select 0) then {
-	_newList set [(count _newList), _x];
+	if (_x select 0 != _toRemove select 0) then {
+		_newList set [(count _newList), _x];
 	};
 } count _friends;
 _thePlot setVariable ["plotfriends", _newList, true];

--- a/SQF/dayz_code/compile/dze_buildChecks.sqf
+++ b/SQF/dayz_code/compile/dze_buildChecks.sqf
@@ -45,7 +45,7 @@ if (_isPole) then {
 	_distance =  DZE_PlotPole select 1;
 	if (DZE_limitPlots && {!(dayz_playerUID in DZE_PlotManagementAdmins)}) then {
 		{
-			if (_x getVariable["ownerPUID","0"] == dayz_playerUID or (_x getVariable["CharacterID","0"] == dayz_characterID)) exitWith {
+			if (_x getVariable["ownerPUID","0"] == dayz_playerUID || (_x getVariable["CharacterID","0"] == dayz_characterID) || ((((_x getVariable ["plotfriends",[]]) select 0) select 0) == dayz_playerUID)) exitWith {
 				_hasPole = true;
 			};
 		} count (entities "Plastic_Pole_EP1_DZ");


### PR DESCRIPTION
Additional work for https://github.com/EpochModTeam/DayZ-Epoch/commit/73899d520fd2fe523ad9b0e28618697aa0933364#diff-0cdf3d56b40b62e92b498e7362874f34

This fixes an issue of players removing them selves from a plot so a friend can become plot owner and bypass the original DZE_limitPlots check

This fixes the checking done not picking up that a player was the owner of the plot by the userlist on the plot when it wasn't them that placed it