### PR TITLE
Updates to zombie and loot spawning

### DIFF
--- a/SQF/dayz_code/compile/building_spawnLoot.sqf
+++ b/SQF/dayz_code/compile/building_spawnLoot.sqf
@@ -1,9 +1,14 @@
 /*
 Spawns loot at the given building.
 
-Single parameter:
-	object		building to spawn loot at
-
+Parameters:
+	obj - building to spawn loot at
+	type - classname of building
+	config - building configs (type, loot chance, loot positions. loot refresh timer)
+	
+Usage:
+	[building,classname,_config] call building_spawnLoot;
+	
 Author:
 	Foxy
 */
@@ -11,37 +16,23 @@ Author:
 #include "\z\addons\dayz_code\util\Vector.hpp"
 #include "\z\addons\dayz_code\loot\Loot.hpp"
 
-private
-[
-	"_vectorUp",
-	"_type",
-	"_config",
-	"_lootChance",
-	"_lootPos",
-	"_lootGroup",
-	"_worldPos",
-	"_existingPile",
-	"_loot"
-];
+private ["_vectorUp","_type","_config","_lootChance","_lootPos","_lootGroup","_worldPos","_existingPile","_loot","_obj"];
 
-_vectorUp = vectorUp _this;
+_obj = _this select 0;
+_type = _this select 1;
+_config = _this select 2;
+_vectorUp = vectorUp _obj;
 if (Vector_Angle(Vector_UP,_vectorUp) > 20) exitWith { 0 };
-
-_type = typeOf _this;
-_config = missionConfigFile >> "CfgLoot" >> "Buildings" >> _type;
-
-if (!isClass _config) exitWith {};
-
 _lootChance = getNumber (_config >> "lootChance");
 
-if (_lootChance <= 0 or ([_this] call DZE_SafeZonePosCheck)) exitWith {};
+if (_lootChance <= 0 or ([_obj] call DZE_SafeZonePosCheck)) exitWith {};
 
 _lootPos = getArray (_config >> "lootPos");
 _lootGroup = Loot_GetGroup(getText(_config >> "lootGroup"));
 
 {
 	//Get the world position of the spawn position
-	_worldPos = _this modelToWorld _x;
+	_worldPos = _obj modelToWorld _x;
 	_worldPos set [2, 0 max (_worldPos select 2)];
 	
 	//Delete existing lootpiles within 1m of spawn location
@@ -68,7 +59,7 @@ if (isArray (_config >> "lootPosSmall")) then {
 	if (_lootGroup >= 1) then {
 		{
 			//Get the world position of the spawn position
-			_worldPos = _this modelToWorld _x;
+			_worldPos = _obj modelToWorld _x;
 			_worldPos set [2, 0 max (_worldPos select 2)];
 			//Delete existing lootpiles within 1m of spawn location
 			{

--- a/SQF/dayz_code/compile/building_spawnZombies.sqf
+++ b/SQF/dayz_code/compile/building_spawnZombies.sqf
@@ -2,28 +2,17 @@
         Created exclusively for ArmA2:OA - DayZMod.
         Please request permission to use/alter/distribute from project leader (R4Z0R49)
 */
-private ["_wreck","_maxlocalspawned","_maxControlledZombies","_iPos","_nearByZed","_nearByPlayer","_rnd","_positions","_zombieChance","_unitTypes","_min","_max","_num","_clean","_obj","_type","_config","_canLoot","_originalPos","_fastRun","_enabled","_i","_Pos"];
-_obj = 			_this select 0;
+private ["_wreck","_iPos","_nearByZed","_nearByPlayer","_rnd","_positions","_zombieChance","_unitTypes","_min","_max","_num","_clean","_obj","_type","_config","_canLoot","_originalPos","_fastRun","_enabled","_i","_Pos"];
+_obj = _this select 0;
+_type = _this select 1;
+_config = _this select 2;
 _wreck = false;
-if (count _this > 1) then {
-	_wreck = 			_this select 1;
+if (count _this > 3) then {
+	_wreck = _this select 3;
 };
-
-_type = 		typeOf _obj;
-_config = missionConfigFile >> "CfgLoot" >> "Buildings" >> _type;
-_canLoot = 		isClass (_config);
 _originalPos = 	getPosATL _obj;
 
-_maxlocalspawned = round(dayz_spawnZombies);
-//Lets check if we need to divide the amount of zeds
-if (r_player_divideinvehicle > 0) then {
-	_maxlocalspawned = round(dayz_spawnZombies / r_player_divideinvehicle);
-};
-
-_maxControlledZombies = round(dayz_maxLocalZombies);
-_enabled = false;
-
-if (_canLoot && !([_originalPos] call DZE_SafeZonePosCheck)) then {
+if (!([_originalPos] call DZE_SafeZonePosCheck)) then {
 	//Get zombie class
 	_unitTypes = 	getArray (_config >> "zombieClass");
 	_min = 			getNumber (_config >> "minRoaming");
@@ -37,7 +26,7 @@ if (_canLoot && !([_originalPos] call DZE_SafeZonePosCheck)) then {
 	for "_i" from 0 to _num do
 	{
 		//_iPos = _obj modelToWorld _originalPos;
-		if ((_maxlocalspawned < _maxControlledZombies) and (dayz_CurrentNearByZombies < dayz_maxNearByZombies) and (dayz_currentGlobalZombies < dayz_maxGlobalZeds)) then {
+		if ((dayz_spawnZombies < dayz_maxControlledZombies) && {dayz_CurrentNearByZombies < dayz_maxNearByZombies} && {dayz_currentGlobalZombies < dayz_maxGlobalZeds}) then {
 			[_originalPos,true,_unitTypes,_wreck] call zombie_generate;
 		};
 	};
@@ -56,8 +45,8 @@ if (_canLoot && !([_originalPos] call DZE_SafeZonePosCheck)) then {
 					_nearByZed = {alive _x} count (_iPos nearEntities ["zZombie_Base",(((sizeOf _type) * 2) + 10)]) > 0;
 					_nearByPlayer = ({isPlayer _x} count (_iPos nearEntities ["CAManBase",30])) > 0;
 					//diag_log ("BUILDING: " + _type + " / " + str(_nearByZed) + " / " + str(_nearByPlayer));
-					if ((_maxlocalspawned < _maxControlledZombies) and (dayz_CurrentNearByZombies < dayz_maxNearByZombies) and (dayz_currentGlobalZombies < dayz_maxGlobalZeds)) then {
-						if (!_nearByPlayer and !_nearByZed) then {
+					if ((dayz_spawnZombies < dayz_maxControlledZombies) && {dayz_CurrentNearByZombies < dayz_maxNearByZombies} && {dayz_currentGlobalZombies < dayz_maxGlobalZeds}) then {
+						if (!_nearByPlayer and {!_nearByZed}) then {
 							[_iPos,false,_unitTypes,false] call zombie_generate;
 						};
 					};

--- a/SQF/dayz_code/init/variables.sqf
+++ b/SQF/dayz_code/init/variables.sqf
@@ -330,8 +330,7 @@ if (!isDedicated) then {
 	inTraderCity = "Unknown Trader";
 	canPickup = false;
 	pickupInit = false;
-	mouseOverCarry = false; //for carry slot since determining mouse pos doesn't work right	
-	r_player_divideinvehicle = 0;
+	mouseOverCarry = false; //for carry slot since determining mouse pos doesn't work right
 	dayz_currentWeaponHolders = 0;
 	dayz_unsaved = false;
 	dayz_scaleLight = 0;

--- a/SQF/dayz_code/system/player_spawn_2.sqf
+++ b/SQF/dayz_code/system/player_spawn_2.sqf
@@ -7,7 +7,6 @@ _isPZombie = player isKindOf "PZombie_VB";
 _radTimer = 0;
 
 _timer = diag_tickTime;
-_timer1 = diag_tickTime;
 _timer30 = diag_Ticktime;
 _timer150 = diag_ticktime;
 _timerMonitor = diag_ticktime;
@@ -344,46 +343,6 @@ while {1 == 1} do {
 		if (_ismelee) then {
 			call dayz_meleeMagazineCheck;
 		};
-	};
-	
-	if ((diag_tickTime - _timer1) > 10) then {
-		_position = getPosATL player;
-			//Other Counters
-		dayz_currentGlobalZombies = count entities "zZombie_Base";
-		_zeds = _position nearEntities ["zZombie_Base",200];
-		dayz_spawnZombies = 0;
-		dayz_CurrentNearByZombies = 0;
-		//Current amounts
-		{
-			if (alive _x) then {
-				if (local _x) then {
-					dayz_spawnZombies = dayz_spawnZombies + 1;
-				};
-				dayz_CurrentNearByZombies = dayz_CurrentNearByZombies + 1;
-			};
-		} count _zeds;
-		
-		//dayz_spawnZombies = {alive _x AND local _x} count (_position nearEntities ["zZombie_Base",400]);
-		//dayz_CurrentNearByZombies = {alive _x} count (_position nearEntities ["zZombie_Base",400]);
-		dayz_currentWeaponHolders = count (_position nearObjects ["ReammoBox",200]);
-		
-		//Remove empty cardborad box's << this needs to be changed moved (action menu or close button)
-		{
-			//get contents
-			_weapons = getWeaponCargo _x;
-			_magazines = getMagazineCargo _x;
-			_backpacks = getBackpackCargo _x;
-			
-			if ((count (_weapons select 0) < 1) and (count (_magazines select 0) < 1) and (count (_backpacks select 0) < 1)) then {
-				//remove vehicle, Need to ask server to remove.
-				diag_log format["Deleting empty nearby box: %1",_x];
-				PVDZ_obj_Delete = [_x,player];
-				publicVariableServer "PVDZ_obj_Delete";
-			};
-		
-		} count (_position nearObjects ["CardboardBox",10]);
-		
-		_timer1 = diag_tickTime;
 	};
 	
 	//Two primary guns pickup exploit fix


### PR DESCRIPTION
Removed a lot of redundancy in the files. Conditions were sometimes being triple checked.
Moved zombie and loot related operations from player_spawn_2 to player_spawnCheck where they are directly used.
Added lazy eval where appropriate.
Better use of global variables used in zombie and loot checks. I'm not sure why global variable values were saved to local variables since the values are changed every time something spawns.
Removing empty Cardboard boxes is no longer necessary. DayZ mod has it's own cardboard box model that inherits from parent class "ReammoBox".
https://github.com/EpochModTeam/DayZ-Epoch/blob/392f8cb7b3fe2b466fa9cf920d2879dc8d4aebe0/SQF/dayz_code/Configs/CfgVehicles/LootContainer.hpp#L33 