### PR TITLE
Fix safe coins refund when packing

### DIFF
--- a/SQF/dayz_server/compile/server_handleSafeGear.sqf
+++ b/SQF/dayz_server/compile/server_handleSafeGear.sqf
@@ -118,7 +118,7 @@ call {
 		_weapons = getWeaponCargo _obj;
 		_magazines = getMagazineCargo _obj;
 		_backpacks = getBackpackCargo _obj;
-		if (_isZSC && {_packedClass in DZE_MoneyStorageClasses}) then {_coins = _obj getVariable ["cashMoney",0];};
+		if (_isZSC) then {_coins = _obj getVariable ["cashMoney",0];};
 
 		_holder = _packedClass createVehicle [0,0,0];
 		deleteVehicle _obj;
@@ -126,7 +126,7 @@ call {
 		_holder setPosATL _pos;
 		_holder addMagazineCargoGlobal [getText(configFile >> "CfgVehicles" >> _packedClass >> "seedItem"),1];
 		[_weapons,_magazines,_backpacks,_holder] call fn_addCargo;
-		if (_isZSC && {_packedClass in DZE_MoneyStorageClasses && {_coins > 0}}) then {
+		if (_isZSC && {_coins > 0}) then {
 			private "_displayName";
 
 			_displayName = getText (configFile >> "CfgVehicles" >> _type >> "displayName");


### PR DESCRIPTION
The check will always return 'false' because packedClass is a Weapon Holder (classname: WeaponHolder_xxx) and those aren't in DZE_MoneyStorageClasses.
And there's no need for that check anyway because the _isZSC variable checks if it's a money storage.